### PR TITLE
Add Init script to set up development shell environment

### DIFF
--- a/Init.cmd
+++ b/Init.cmd
@@ -1,0 +1,8 @@
+@echo off
+@rem Windows 7/8/10 may not allow powershell scripts by default
+powershell -Command Set-ExecutionPolicy -Scope CurrentUser Unrestricted
+
+@rem Setup init environment
+pushd "%CMDHOME%"
+powershell -f Init.ps1 -SetupEnv
+popd

--- a/Init.ps1
+++ b/Init.ps1
@@ -35,7 +35,7 @@ process
         }
     }
 
-    $Root = Get-ScriptDirectory
+    $Global:Root = Get-ScriptDirectory
 
     function Create-ShortCut {
         try

--- a/Init.ps1
+++ b/Init.ps1
@@ -1,0 +1,126 @@
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+<#
+.SYNOPSIS
+    Sets up and initialize the developer Shell Environment for Mobius
+.DESCRIPTION
+    Sets up the proper PATH and ENV to use Posh-Git shell and build environment
+#>
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory = $false)]
+    [switch]$SetupEnv
+)
+
+process
+{
+    $projectName = "Mobius"
+    $latestVs = $null
+
+    function Get-ScriptDirectory
+    {
+        $Invocation = (Get-Variable MyInvocation -Scope 1).Value;
+        if($Invocation.PSScriptRoot -and $Invocation.CommandOrigin -eq "Runspace")
+        {
+            $Invocation.PSScriptRoot;
+        }
+        Elseif($Invocation.MyCommand.Path)
+        {
+            Split-Path $Invocation.MyCommand.Path
+        }
+        else
+        {
+            $Invocation.InvocationName.Substring(0,$Invocation.InvocationName.LastIndexOf("\"));
+        }
+    }
+
+    $Root = Get-ScriptDirectory
+
+    function Create-ShortCut {
+        try
+        {
+            $linkFileName = [IO.Path]::ChangeExtension($projectName, "lnk")
+            $linkFile = [IO.Path]::Combine("$env:USERPROFILE\Desktop", $linkFileName)
+            if (Test-Path $linkFile)
+            {
+                Write-Warning "The shortcut of $projectName already be created in your desktop. Skipped to create shortcut."
+                return
+            }
+
+            # create ShortCut
+            $wshshell = New-Object -ComObject WScript.Shell
+            $shortCut = $wshShell.CreateShortCut($LinkFile)
+            $shortCut.TargetPath = "cmd.exe"
+            $shortCut.WorkingDirectory = $Root
+            $shortCut.IconLocation = "PowerShell.exe"
+            $shortCut.Arguments = "/k """"%$latestVs%\VsDevCmd.bat"" & PowerShell.exe -NoExit -Command ""$Root\Init.ps1"""""
+            $shortCut.Save()
+
+            # Change Elevation Flag
+            $bytes = [IO.File]::ReadAllBytes($linkFile)
+            $bytes[0x15] = $bytes[0x15] -bor 0x20 #set byte 21 (0x15) bit 6 (0x20) ON
+            [IO.File]::WriteAllBytes($linkFile, $bytes)
+        }
+        catch
+        {
+            Write-Error "Failed to create shortcut for $projectName. The error was '$_'."
+        }
+    }
+
+    function Create-Alias {
+        # pull together all the args and then split on =
+        $alias,$cmd = [string]::join(" ",$args).split("=",2) | % { $_.trim()}
+        $func = @"
+function global:Alias$alias {
+    `$expr = ('$cmd ' + (( `$args | % { if (`$_.GetType().FullName -eq "System.String") { "``"`$(`$_.Replace('``"','````"').Replace("'","``'"))``"" } else { `$_ } } ) -join ' '))
+    write-debug "Expression: `$expr"
+    Invoke-Expression `$expr
+}
+"@
+        write-debug "Defined function:`n$func"
+        $func | iex
+        $newAlias = Set-Alias -Name $alias -Value "Alias$alias" -Description "$cmd" -Option AllScope -scope Global -passThru
+    }
+
+    if ($SetupEnv) {
+        # Check if the GitHub for Windows is installed
+        if (!(Test-Path "$env:LOCALAPPDATA\GitHub"))
+        {
+            $Host.UI.WriteErrorLine("The development enviroment requires ""GitHub Desktop"" be installed. You can download from https://desktop.github.com/")
+            return
+        }
+
+        # Check if Visual Studio in installed
+        $vsEnvVars = (dir Env:).Name -match "VS[0-9]{1,3}COMNTOOLS"
+        $latestVs = $vsEnvVars | Sort-Object | Select -Last 1
+        if (!$latestVs)
+        {
+            $Host.UI.WriteErrorLine("The development enviroment requires ""Visual Studio"" be installed. Please install it first.")
+            return
+        }
+
+        # Create shortcut for Mobius
+        Create-ShortCut
+
+        # Download build tool
+        & $Root\build\localmode\downloadtools.ps1 build
+        & $Root\build\tools\updatebuildtoolenv.cmd
+        return
+    }
+
+    # Import Github Shell environment
+    . (Resolve-Path "$env:LOCALAPPDATA\GitHub\shell.ps1")
+    . (Resolve-Path "$env:github_posh_git\profile.example.ps1")
+    cd $Root
+
+    # Create aliases
+    if (Test-Path "$Root\build\aliases")
+    {
+        Get-Content "$Root\build\aliases\*.txt" -Force | % {
+            if ($_ -ne "") {
+                Create-Alias $_
+            }
+        }
+    }
+}

--- a/build/aliases/aliases.txt
+++ b/build/aliases/aliases.txt
@@ -1,0 +1,28 @@
+root	= pushd $Root\
+build	= $Root\build\build.cmd
+
+..	= cd ..
+n	= notepad.exe
+n++	= notepad++.exe
+
+ga	= git add
+gco	= git checkout
+gb	= git branch
+gba	= git branch -a
+gbr	= git branch --remote
+gtc	= git commit
+gcp	= git cherry-pick
+gd	= git diff
+gdt	= git difftool
+gpll	= git pull
+gpsh	= git push
+gk	= gitk
+glg	= git log
+gtm	= git merge
+gmt	= git mergetool
+gr	= git remote
+grb	= git rebase
+grbi	= git rebase -i
+gs	= git status
+gsta	= git stash
+gstd	= git stash drop

--- a/build/aliases/aliases.txt
+++ b/build/aliases/aliases.txt
@@ -1,5 +1,5 @@
 root	= pushd $Root\
-build	= $Root\build\build.cmd
+build	= & $Root\build\build.cmd
 
 ..	= cd ..
 n	= notepad.exe

--- a/build/localmode/downloadtools.ps1
+++ b/build/localmode/downloadtools.ps1
@@ -20,7 +20,7 @@ if ($stage.ToLower() -eq "run")
 function Get-ScriptDirectory
 {
     $Invocation = (Get-Variable MyInvocation -Scope 1).Value;
-    if($Invocation.PSScriptRoot)
+    if($Invocation.PSScriptRoot -and $Invocation.CommandOrigin -eq "Runspace")
     {
         $Invocation.PSScriptRoot;
     }


### PR DESCRIPTION
Adding Init script to set up the proper PATH and ENV to use Github shell and build environment.
1. After running Init.cmd, it will create a powershell shortcut for Mobius project in which you can use posh-git shell and build directly from that window. It also to call \build\localmode\downloadtools.ps1 to download build tool.
2. When you click the shortcut for Mobius from your desktop, it will do the following jobs:
    - Import GitHub Shell ENV
    - Import EVN of Developer Command Prompt for VS
    - Create batch of alias from build\aliases (e.g. n for notepad, .. for cd .., gco for git checkout)