### PR TITLE
Improve unit test coverage in SQL namespace

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Interop/SparkCLREnvironment.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Interop/SparkCLREnvironment.cs
@@ -8,6 +8,7 @@ using Microsoft.Spark.CSharp.Interop.Ipc;
 using Microsoft.Spark.CSharp.Proxy;
 using Microsoft.Spark.CSharp.Proxy.Ipc;
 
+[assembly: InternalsVisibleTo("Tests.Common")]
 [assembly: InternalsVisibleTo("AdapterTest")]
 [assembly: InternalsVisibleTo("WorkerTest")]
 // DynamicProxyGenAssembly2 is a temporary assembly built by mocking systems that use CastleProxy like Moq

--- a/csharp/AdapterTest/RowTest.cs
+++ b/csharp/AdapterTest/RowTest.cs
@@ -2,140 +2,68 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using NUnit.Framework;
-using Microsoft.Spark.CSharp.Proxy;
-using Moq;
 using Microsoft.Spark.CSharp.Sql;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using Microsoft.CSharp.RuntimeBinder;
+using Tests.Common;
 
 namespace AdapterTest
 {
     [TestFixture]
     public class RowTest
     {
-        private static StructType complexSchema;
-        private const string complexJsonSchema = @"
-                {
-                  ""type"" : ""struct"",
-                  ""fields"" : [ {
-                    ""name"" : ""address"",
-                    ""type"" : {
-                      ""type"" : ""struct"",
-                      ""fields"" : [ {
-                        ""name"" : ""city"",
-                        ""type"" : ""string"",
-                        ""nullable"" : true,
-                        ""metadata"" : { }
-                      }, {
-                        ""name"" : ""state"",
-                        ""type"" : ""string"",
-                        ""nullable"" : true,
-                        ""metadata"" : { }
-                      } ]
-                    },
-                    ""nullable"" : true,
-                    ""metadata"" : { }
-                  }, {
-                    ""name"" : ""age"",
-                    ""type"" : ""long"",
-                    ""nullable"" : true,
-                    ""metadata"" : { }
-                  }, {
-                    ""name"" : ""id"",
-                    ""type"" : ""string"",
-                    ""nullable"" : true,
-                    ""metadata"" : { }
-                  }, {
-                    ""name"" : ""name"",
-                    ""type"" : ""string"",
-                    ""nullable"" : true,
-                    ""metadata"" : { }
-                  } ]
-                }";
-
-
-        private static StructType basicSchema;
-        private const string basicJsonSchema = @"
-                {
-                  ""type"" : ""struct"",
-                  ""fields"" : [{
-                    ""name"" : ""age"",
-                    ""type"" : ""long"",
-                    ""nullable"" : true,
-                    ""metadata"" : { }
-                  }, {
-                    ""name"" : ""id"",
-                    ""type"" : ""string"",
-                    ""nullable"" : true,
-                    ""metadata"" : { }
-                  }, {
-                    ""name"" : ""name"",
-                    ""type"" : ""string"",
-                    ""nullable"" : true,
-                    ""metadata"" : { }
-                  } ]
-                }";
-
-        [OneTimeSetUp]
-        public static void Initialize()
-        {
-            basicSchema = new StructType(JObject.Parse(basicJsonSchema));
-            complexSchema = new StructType(JObject.Parse(complexJsonSchema));
-        }
-
         [Test]
         public void RowConstructTest()
         {
-            Row row1 = new RowImpl(new object[]{1, "id", "name"}, basicSchema);
-            Row row2 = new RowImpl(new List<object>(){1, "id", "name"}, basicSchema);
+            Row row1 = new RowImpl(new object[]{1, "id", "name"}, RowHelper.BasicSchema);
+            Row row2 = new RowImpl(new List<object> {1, "id", "name"}, RowHelper.BasicSchema);
             
             // dynamic data tyoe is not array or list
-            Assert.Throws(typeof(Exception), new TestDelegate(() => { new RowImpl(new object(), basicSchema); }));
+            Assert.Throws(typeof(Exception), () => { new RowImpl(new object(), RowHelper.BasicSchema); });
 
             // dynamic data count is not same with its schema
-            Assert.Throws(typeof(Exception), new TestDelegate(() => { new RowImpl(new List<object>() { "id", "name" }, basicSchema); }));
+            Assert.Throws(typeof(Exception), () => { new RowImpl(new List<object> { "id", "name" }, RowHelper.BasicSchema); });
 
             // complex scheme
-            Row row3 = new RowImpl(new object[]{ new object[]{"redmond", "washington"}, 1, "id", "name"}, complexSchema);
+            Row row3 = new RowImpl(new object[]{ new object[]{"redmond", "washington"}, 1, "id", "name"}, RowHelper.ComplexSchema);
         }
 
         [Test]
         public void RowGetTest()
         {
-            Row row = new RowImpl(new object[] { 1, "1234", "John" }, basicSchema);
+            Row row = new RowImpl(new object[] { 1, "1234", "John" }, RowHelper.BasicSchema);
             Assert.AreEqual(row.Get(0), 1);
             Assert.AreEqual(row.Get(1), "1234");
             Assert.AreEqual(row.Get(2), "John");
-            Assert.Throws(typeof(Exception), new TestDelegate(() => { row.Get(3); }));
+            Assert.Throws(typeof(Exception), () => { row.Get(3); });
 
             Assert.AreEqual(row.Get("age"), 1);
             Assert.AreEqual(row.Get("id"), "1234");
             Assert.AreEqual(row.Get("name"), "John");
-            Assert.Throws(typeof(Exception), new TestDelegate(() => { row.Get("address"); }));
+            Assert.Throws(typeof(Exception), () => { row.Get("address"); });
 
             Assert.AreEqual(row.Size(), 3);
 
             Assert.AreEqual(row.GetAs<long>(0), 1);
             Assert.AreEqual(row.GetAs<string>(1), "1234");
             Assert.AreEqual(row.GetAs<string>(2), "John");
-            Assert.Throws(typeof(RuntimeBinderException), new TestDelegate(() => { row.GetAs<int>(1); }));
+            Assert.Throws(typeof(RuntimeBinderException), () => { row.GetAs<int>(1); });
 
             Assert.AreEqual(row.GetAs<long>("age"), 1);
             Assert.AreEqual(row.GetAs<string>("id"), "1234");
             Assert.AreEqual(row.GetAs<string>("name"), "John");
-            Assert.Throws(typeof(RuntimeBinderException), new TestDelegate(() => { row.GetAs<int>("id"); }));
+            Assert.Throws(typeof(RuntimeBinderException), () => { row.GetAs<int>("id"); });
         }
 
         [Test]
         public void RowToStringTest()
         {
-            Row row1 = new RowImpl(new object[] { 1, "1234", "John" }, basicSchema);
+            Row row1 = new RowImpl(new object[] { 1, "1234", "John" }, RowHelper.BasicSchema);
             string result1 = row1.ToString();
             Assert.AreEqual(result1, "[1,1234,John]");
 
-            Row row2 = new RowImpl(new object[] { 1, "1234", null }, basicSchema);
+            Row row2 = new RowImpl(new object[] { 1, "1234", null }, RowHelper.BasicSchema);
             string result2 = row2.ToString();
             Assert.AreEqual(result2, "[1,1234,]");
         }

--- a/csharp/AdapterTest/SqlContextTest.cs
+++ b/csharp/AdapterTest/SqlContextTest.cs
@@ -22,6 +22,15 @@ namespace AdapterTest
     public class SqlContextTest
     {
         private static Mock<ISqlContextProxy> mockSqlContextProxy;
+        private const string SchemaJson = @"{
+                                    ""fields"": [{
+		                                ""metadata"": {},
+		                                ""name"": ""guid"",
+		                                ""nullable"": false,
+		                                ""type"": ""string""
+	                                }],
+	                                ""type"": ""struct""
+                                    }";
 
         [OneTimeSetUp]
         public static void ClassInitialize()
@@ -50,6 +59,13 @@ namespace AdapterTest
         }
 
         [Test]
+        public void TestSqlContextGetOrCreate()
+        {
+            var sqlContext = SqlContext.GetOrCreate(new SparkContext("", ""));
+            Assert.IsNotNull(sqlContext.SqlContextProxy);
+        }
+
+        [Test]
         public void TestSqlContextNewSession()
         {
             // arrange
@@ -70,7 +86,6 @@ namespace AdapterTest
             // arrange
             const string key = "key";
             const string value = "value";
-            var sessionProxy = new SqlContextIpcProxy(new JvmObjectReference("1"));
             mockSqlContextProxy.Setup(m => m.GetConf(key, "")).Returns(value);
             var sqlContext = new SqlContext(new SparkContext("", ""), mockSqlContextProxy.Object);
 
@@ -98,6 +113,23 @@ namespace AdapterTest
         }
 
         [Test]
+        public void TestSqlContextReadDataFrame()
+        {
+            var dataFrameProxy = new DataFrameIpcProxy(new JvmObjectReference("1"), mockSqlContextProxy.Object);
+            mockSqlContextProxy.Setup(
+                m => m.ReadDataFrame(It.IsAny<string>(), It.IsAny<StructType>(), It.IsAny<Dictionary<string, string>>()))
+                .Returns(dataFrameProxy);
+            var sqlContext = new SqlContext(new SparkContext("", ""), mockSqlContextProxy.Object);
+            var structTypeProxy = new Mock<IStructTypeProxy>();
+            structTypeProxy.Setup(m => m.ToJson()).Returns(SchemaJson);
+            // act
+            var dataFrame = sqlContext.ReadDataFrame(@"c:\path\to\input.txt", new StructType(structTypeProxy.Object), null);
+
+            // assert
+            Assert.AreEqual(dataFrameProxy, dataFrame.DataFrameProxy);
+        }
+
+        [Test]
         public void TestSqlContextCreateDataFrame()
         {
             // arrange
@@ -110,16 +142,7 @@ namespace AdapterTest
             mockSqlContextProxy.Setup(m => m.CreateDataFrame(It.IsAny<IRDDProxy>(), It.IsAny<IStructTypeProxy>())).Returns(dataFrameProxy);
             var sqlContext = new SqlContext(new SparkContext("", ""), mockSqlContextProxy.Object);
             var structTypeProxy = new Mock<IStructTypeProxy>();
-            const string schemaJson = @"{
-	                                ""fields"": [{
-		                                ""metadata"": {},
-		                                ""name"": ""guid"",
-		                                ""nullable"": false,
-		                                ""type"": ""string""
-	                                }],
-	                                ""type"": ""struct""
-                                    }";
-            structTypeProxy.Setup(m => m.ToJson()).Returns(schemaJson);
+            structTypeProxy.Setup(m => m.ToJson()).Returns(SchemaJson);
             // act
             var dataFrame = sqlContext.CreateDataFrame(rdd, new StructType(structTypeProxy.Object));
 
@@ -259,11 +282,34 @@ namespace AdapterTest
         }
 
         [Test]
+        public void TestSqlContextIsCached()
+        {
+            // arrange
+            mockSqlContextProxy.Setup(m => m.IsCached(It.IsAny<string>()));
+            var sqlContext = new SqlContext(new SparkContext("", ""), mockSqlContextProxy.Object);
+
+            // act
+            sqlContext.IsCached("table");
+
+            // assert
+            mockSqlContextProxy.Verify(m => m.IsCached("table"));
+        }
+
+        [Test]
+        public void TestSqlContextSql()
+        {
+            var sqlContext = new SqlContext(new SparkContext("", ""));
+            var dataFrame = sqlContext.Sql("Query of SQL text");
+            var paramValuesToJsonFileMethod = (dataFrame.DataFrameProxy as MockDataFrameProxy).mockDataFrameReference;
+            Assert.AreEqual("Query of SQL text", paramValuesToJsonFileMethod[0]);
+        }
+
+        [Test]
         public void TestSqlContextJsonFile()
         {
             var sqlContext = new SqlContext(new SparkContext("", "")); 
             var dataFrame = sqlContext.Read().Json(@"c:\path\to\input.json");
-            var paramValuesToJsonFileMethod = (dataFrame.DataFrameProxy as MockDataFrameProxy).mockDataFrameReference as object[];
+            var paramValuesToJsonFileMethod = (dataFrame.DataFrameProxy as MockDataFrameProxy).mockDataFrameReference;
             Assert.AreEqual(@"c:\path\to\input.json", paramValuesToJsonFileMethod[0]);
         }
 
@@ -272,7 +318,7 @@ namespace AdapterTest
         {
             var sqlContext = new SqlContext(new SparkContext("", ""));
             var dataFrame = sqlContext.TextFile(@"c:\path\to\input.txt");
-            var paramValuesToTextFileMethod = (dataFrame.DataFrameProxy as MockDataFrameProxy).mockDataFrameReference as object[];
+            var paramValuesToTextFileMethod = (dataFrame.DataFrameProxy as MockDataFrameProxy).mockDataFrameReference;
             Assert.AreEqual(@"c:\path\to\input.txt", paramValuesToTextFileMethod[0]);
             Assert.AreEqual(@",", paramValuesToTextFileMethod[1]);
             Assert.IsFalse(bool.Parse(paramValuesToTextFileMethod[2].ToString()));
@@ -280,11 +326,62 @@ namespace AdapterTest
 
             sqlContext = new SqlContext(new SparkContext("", "")); 
             dataFrame = sqlContext.TextFile(@"c:\path\to\input.txt", "|", true, true);
-            paramValuesToTextFileMethod = (dataFrame.DataFrameProxy as MockDataFrameProxy).mockDataFrameReference as object[];
+            paramValuesToTextFileMethod = (dataFrame.DataFrameProxy as MockDataFrameProxy).mockDataFrameReference;
             Assert.AreEqual(@"c:\path\to\input.txt", paramValuesToTextFileMethod[0]);
             Assert.AreEqual(@"|", paramValuesToTextFileMethod[1]);
             Assert.IsTrue(bool.Parse(paramValuesToTextFileMethod[2].ToString()));
             Assert.IsTrue(bool.Parse(paramValuesToTextFileMethod[3].ToString()));
+
+            // Test with a given schema
+            sqlContext = new SqlContext(new SparkContext("", ""));
+            var structTypeProxy = new Mock<IStructTypeProxy>();
+            structTypeProxy.Setup(m => m.ToJson()).Returns(SchemaJson);
+            var structType = new StructType(structTypeProxy.Object);
+            dataFrame = sqlContext.TextFile(@"c:\path\to\input.txt", structType);
+            paramValuesToTextFileMethod = (dataFrame.DataFrameProxy as MockDataFrameProxy).mockDataFrameReference;
+            Assert.AreEqual(@"c:\path\to\input.txt", paramValuesToTextFileMethod[0]);
+            Assert.AreEqual(structType, paramValuesToTextFileMethod[1]);
+            Assert.AreEqual(@",", paramValuesToTextFileMethod[2]);
+        }
+
+        [Test]
+        public void TestSqlContextRegisterFunction()
+        {
+            mockSqlContextProxy.Setup(m => m.RegisterFunction(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<string>()));
+            var sqlContext = new SqlContext(new SparkContext("", ""), mockSqlContextProxy.Object);
+
+            sqlContext.RegisterFunction("Func0", () => "Func0");
+            mockSqlContextProxy.Verify(m => m.RegisterFunction("Func0", It.IsAny<byte[]>(), "string"));
+
+            sqlContext.RegisterFunction<string, string>("Func1", s => "Func1");
+            mockSqlContextProxy.Verify(m => m.RegisterFunction("Func1", It.IsAny<byte[]>(), "string"));
+
+            sqlContext.RegisterFunction<string, string, string>("Func2", (s1, s2) => "Func2");
+            mockSqlContextProxy.Verify(m => m.RegisterFunction("Func2", It.IsAny<byte[]>(), "string"));
+
+            sqlContext.RegisterFunction<string, string, string, string>("Func3", (s1, s2, s3) => "Func3");
+            mockSqlContextProxy.Verify(m => m.RegisterFunction("Func3", It.IsAny<byte[]>(), "string"));
+
+            sqlContext.RegisterFunction<string, string, string, string, string>("Func4", (s1, s2, s3, s4) => "Func4");
+            mockSqlContextProxy.Verify(m => m.RegisterFunction("Func4", It.IsAny<byte[]>(), "string"));
+
+            sqlContext.RegisterFunction<string, string, string, string, string, string>("Func5", (s1, s2, s3, s4, s5) => "Func5");
+            mockSqlContextProxy.Verify(m => m.RegisterFunction("Func5", It.IsAny<byte[]>(), "string"));
+
+            sqlContext.RegisterFunction<string, string, string, string, string, string, string>("Func6", (s1, s2, s3, s4, s5, s6) => "Func6");
+            mockSqlContextProxy.Verify(m => m.RegisterFunction("Func6", It.IsAny<byte[]>(), "string"));
+
+            sqlContext.RegisterFunction<string, string, string, string, string, string, string, string>("Func7", (s1, s2, s3, s4, s5, s6, s7) => "Func7");
+            mockSqlContextProxy.Verify(m => m.RegisterFunction("Func7", It.IsAny<byte[]>(), "string"));
+
+            sqlContext.RegisterFunction<string, string, string, string, string, string, string, string, string>("Func8", (s1, s2, s3, s4, s5, s6, s7, s8) => "Func8");
+            mockSqlContextProxy.Verify(m => m.RegisterFunction("Func8", It.IsAny<byte[]>(), "string"));
+
+            sqlContext.RegisterFunction<string, string, string, string, string, string, string, string, string, string>("Func9", (s1, s2, s3, s4, s5, s6, s7, s8, s9) => "Func9");
+            mockSqlContextProxy.Verify(m => m.RegisterFunction("Func9", It.IsAny<byte[]>(), "string"));
+
+            sqlContext.RegisterFunction<string, string, string, string, string, string, string, string, string, string, string>("Func10", (s1, s2, s3, s4, s5, s6, s7, s8, s9, s10) => "Func10");
+            mockSqlContextProxy.Verify(m => m.RegisterFunction("Func10", It.IsAny<byte[]>(), "string"));
         }
     }
 }

--- a/csharp/SparkCLR.sln
+++ b/csharp/SparkCLR.sln
@@ -21,6 +21,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WorkerTest", "WorkerTest\Wo
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Utils", "Utils\Microsoft.Spark.CSharp\Utils.csproj", "{6A118B6B-42F2-4017-B0F5-2FA15007B159}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.Common", "Tests.Common\Tests.Common.csproj", "{E4479C4C-E106-4B90-BF0C-319561CEA9C4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,10 @@ Global
 		{6A118B6B-42F2-4017-B0F5-2FA15007B159}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6A118B6B-42F2-4017-B0F5-2FA15007B159}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6A118B6B-42F2-4017-B0F5-2FA15007B159}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E4479C4C-E106-4B90-BF0C-319561CEA9C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4479C4C-E106-4B90-BF0C-319561CEA9C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E4479C4C-E106-4B90-BF0C-319561CEA9C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E4479C4C-E106-4B90-BF0C-319561CEA9C4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/csharp/Tests.Common/Picklers.cs
+++ b/csharp/Tests.Common/Picklers.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using Microsoft.Spark.CSharp.Interop.Ipc;
+using Microsoft.Spark.CSharp.Sql;
+using Razorvine.Pickle;
+
+namespace Tests.Common
+{
+    /// <summary>
+    /// Used to pickle StructType objects
+    /// Reference: StructTypePickler from https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/python.scala#L240
+    /// </summary>
+    internal class StructTypePickler : IObjectPickler
+    {
+        private const string Module = "pyspark.sql.types";
+
+        public void Register()
+        {
+            Pickler.registerCustomPickler(GetType(), this);
+            Pickler.registerCustomPickler(typeof(StructType), this);
+        }
+
+        public void pickle(object o, Stream stream, Pickler currentPickler)
+        {
+            var schema = o as StructType;
+            if (schema == null)
+            {
+                throw new InvalidOperationException(GetType().Name + " only accepts 'StructType' type objects.");
+            }
+
+            SerDe.Write(stream, Opcodes.GLOBAL);
+            SerDe.Write(stream, Encoding.UTF8.GetBytes(Module + "\n" + "_parse_datatype_json_string" + "\n"));
+            currentPickler.save(schema.Json);
+            SerDe.Write(stream, Opcodes.TUPLE1);
+            SerDe.Write(stream, Opcodes.REDUCE);
+        }
+    }
+
+    /// <summary>
+    /// Used to pickle Row objects
+    /// Reference: RowPickler from https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/python.scala#L261
+    /// </summary>
+    internal class RowPickler : IObjectPickler
+    {
+        private const string Module = "pyspark.sql.types";
+
+        public void Register()
+        {
+            Pickler.registerCustomPickler(GetType(), this);
+            Pickler.registerCustomPickler(typeof(Row), this);
+            Pickler.registerCustomPickler(typeof(RowImpl), this);
+        }
+
+        public void pickle(object o, Stream stream, Pickler currentPickler)
+        {
+            if (o.Equals(this))
+            {
+                SerDe.Write(stream, Opcodes.GLOBAL);
+                SerDe.Write(stream, Encoding.UTF8.GetBytes(Module + "\n" + "_create_row_inbound_converter" + "\n"));
+            }
+            else
+            {
+                var row = o as Row;
+                if (row == null)
+                {
+                    throw new InvalidOperationException(GetType().Name + " only accepts 'Row' type objects.");
+                }
+
+                currentPickler.save(this);
+                currentPickler.save(row.GetSchema());
+                SerDe.Write(stream, Opcodes.TUPLE1);
+                SerDe.Write(stream, Opcodes.REDUCE);
+
+                SerDe.Write(stream, Opcodes.MARK);
+
+                var i = 0;
+                while (i < row.Size())
+                {
+                    currentPickler.save(row.Get(i));
+                    i++;
+                }
+
+                SerDe.Write(stream, Opcodes.TUPLE);
+                SerDe.Write(stream, Opcodes.REDUCE);
+            }
+        }
+    }
+}

--- a/csharp/Tests.Common/Properties/AssemblyInfo.cs
+++ b/csharp/Tests.Common/Properties/AssemblyInfo.cs
@@ -1,0 +1,39 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Tests.Common")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Tests.Common")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: InternalsVisibleTo("AdapterTest")]
+[assembly: InternalsVisibleTo("WorkerTest")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e4479c4c-e106-4b90-bf0c-319561cea9c4")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/csharp/Tests.Common/RowHelper.cs
+++ b/csharp/Tests.Common/RowHelper.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Spark.CSharp.Sql;
+
+namespace Tests.Common
+{
+    internal class RowHelper
+    {
+        public const string BasicJsonSchema = @"
+                {
+                  ""type"" : ""struct"",
+                  ""fields"" : [{
+                    ""name"" : ""age"",
+                    ""type"" : ""long"",
+                    ""nullable"" : true,
+                    ""metadata"" : { }
+                  }, {
+                    ""name"" : ""id"",
+                    ""type"" : ""string"",
+                    ""nullable"" : true,
+                    ""metadata"" : { }
+                  }, {
+                    ""name"" : ""name"",
+                    ""type"" : ""string"",
+                    ""nullable"" : true,
+                    ""metadata"" : { }
+                  } ]
+                }";
+
+        public const string ComplexJsonSchema = @"
+                {
+                  ""type"" : ""struct"",
+                  ""fields"" : [ {
+                    ""name"" : ""address"",
+                    ""type"" : {
+                      ""type"" : ""struct"",
+                      ""fields"" : [ {
+                        ""name"" : ""city"",
+                        ""type"" : ""string"",
+                        ""nullable"" : true,
+                        ""metadata"" : { }
+                      }, {
+                        ""name"" : ""state"",
+                        ""type"" : ""string"",
+                        ""nullable"" : true,
+                        ""metadata"" : { }
+                      } ]
+                    },
+                    ""nullable"" : true,
+                    ""metadata"" : { }
+                  }, {
+                    ""name"" : ""age"",
+                    ""type"" : ""long"",
+                    ""nullable"" : true,
+                    ""metadata"" : { }
+                  }, {
+                    ""name"" : ""id"",
+                    ""type"" : ""string"",
+                    ""nullable"" : true,
+                    ""metadata"" : { }
+                  }, {
+                    ""name"" : ""name"",
+                    ""type"" : ""string"",
+                    ""nullable"" : true,
+                    ""metadata"" : { }
+                  } ]
+                }";
+
+        public static readonly StructType BasicSchema;
+        public static readonly StructType ComplexSchema;
+
+        static RowHelper()
+        {
+            BasicSchema = DataType.ParseDataTypeFromJson(BasicJsonSchema) as StructType;
+            ComplexSchema = DataType.ParseDataTypeFromJson(ComplexJsonSchema) as StructType;
+        }
+
+        public static Row BuildRowForBasicSchema(int seqId)
+        {
+            return new RowImpl(new object[] { seqId, "id " + seqId, "name" + seqId }, BasicSchema);
+        }
+    }
+}

--- a/csharp/Tests.Common/Tests.Common.csproj
+++ b/csharp/Tests.Common/Tests.Common.csproj
@@ -3,11 +3,11 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{D5C2C46E-3FEC-473B-8ABA-3B0FC5A7319C}</ProjectGuid>
+    <ProjectGuid>{E4479C4C-E106-4B90-BF0C-319561CEA9C4}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>AdapterTest</RootNamespace>
-    <AssemblyName>AdapterTest</AssemblyName>
+    <RootNamespace>Tests.Common</RootNamespace>
+    <AssemblyName>Tests.Common</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -16,6 +16,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -35,26 +36,15 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Razorvine.Pyrolite">
       <HintPath>..\packages\Razorvine.Pyrolite.4.10.0.0\lib\net40\Razorvine.Pyrolite.dll</HintPath>
     </Reference>
-    <Reference Include="Razorvine.Serpent">
-      <HintPath>..\packages\Razorvine.Serpent.1.12.0.0\lib\net40\Razorvine.Serpent.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Configuration" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -65,64 +55,15 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
-    <Compile Include="ColumnTest.cs" />
-    <Compile Include="AccumulatorTest.cs" />
-    <Compile Include="BroadcastTest.cs" />
-    <Compile Include="ConfigurationServiceTest.cs" />
-    <Compile Include="DataFrameNaFunctionsTest.cs" />
-    <Compile Include="DataFrameReaderTest.cs" />
-    <Compile Include="DataFrameWriterTest.cs" />
-    <Compile Include="EventHubsUtilsTest.cs" />
-    <Compile Include="JsonSerDeTest.cs" />
-    <Compile Include="FunctionsTest.cs" />
-    <Compile Include="Mocks\MockDataFrameReaderProxy.cs" />
-    <Compile Include="Mocks\MockRDDCollector.cs" />
-    <Compile Include="Mocks\MockRow.cs" />
-    <Compile Include="PayloadHelperTest.cs" />
+    <Compile Include="Picklers.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="RowTest.cs" />
-    <Compile Include="SerDeTest.cs" />
-    <Compile Include="HiveContextTest.cs" />
-    <Compile Include="StatusTrackerTest.cs" />
-    <Compile Include="TestWithMoqDemo.cs" />
-    <Compile Include="Mocks\MockStructTypeProxy.cs" />
-    <Compile Include="DStreamTest.cs" />
-    <Compile Include="Mocks\MockDStreamProxy.cs" />
-    <Compile Include="Mocks\MockStreamingContextProxy.cs" />
-    <Compile Include="SparkCLRTestEnvironment.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="DataFrameTest.cs" />
-    <Compile Include="Mocks\MockSparkCLRProxy.cs" />
-    <Compile Include="Mocks\MockConfigurationService.cs" />
-    <Compile Include="Mocks\MockDataFrameProxy.cs" />
-    <Compile Include="Mocks\MockRddProxy.cs" />
-    <Compile Include="Mocks\MockSparkConfProxy.cs" />
-    <Compile Include="Mocks\MockSparkContextProxy.cs" />
-    <Compile Include="Mocks\MockSqlContextProxy.cs" />
-    <Compile Include="RDDTest.cs" />
-    <Compile Include="SparkConfTest.cs" />
-    <Compile Include="SparkContextTest.cs" />
-    <Compile Include="SqlContextTest.cs" />
-    <Compile Include="StreamingContextTest.cs" />
-    <Compile Include="PairRDDTest.cs" />
-    <Compile Include="ComparableRDDTest.cs" />
-    <Compile Include="DoubleRDDTest.cs" />
-    <Compile Include="UserDefinedFunctionTest.cs" />
+    <Compile Include="RowHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Adapter\Microsoft.Spark.CSharp\Adapter.csproj">
       <Project>{ce999a96-f42b-4e80-b208-709d7f49a77c}</Project>
       <Name>Adapter</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Tests.Common\Tests.Common.csproj">
-      <Project>{e4479c4c-e106-4b90-bf0c-319561cea9c4}</Project>
-      <Name>Tests.Common</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup />
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/csharp/WorkerTest/WorkerTest.csproj
+++ b/csharp/WorkerTest/WorkerTest.csproj
@@ -59,6 +59,10 @@
       <Project>{ce999a96-f42b-4e80-b208-709d7f49a77c}</Project>
       <Name>Adapter</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Tests.Common\Tests.Common.csproj">
+      <Project>{e4479c4c-e106-4b90-bf0c-319561cea9c4}</Project>
+      <Name>Tests.Common</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Worker\Microsoft.Spark.CSharp\Worker.csproj">
       <Project>{82c9d3b2-e4fb-4713-b980-948c1e96a10a}</Project>
       <Name>Worker</Name>


### PR DESCRIPTION
1. Add unit tests to improve code coverage for "SQL" namespace
2. Create a new common library that shared by AdapterTest and WorkerTest. And move common code to the new library.