### PR TITLE
Fix Build.cmd to include examples binaries in release zip file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 scala/dependency-reduced-pom.xml
 build/runtime/
 build/tools/
+build/examples/
 *.log
 lib/
 

--- a/build/Build.cmd
+++ b/build/Build.cmd
@@ -133,6 +133,32 @@ popd
 pushd "%CMDHOME%\..\examples"
 call Clean.cmd
 call Build.cmd
+
+set EXAMPLES_HOME=%CMDHOME%\examples
+@echo set EXAMPLES_HOME=%EXAMPLES_HOME%
+
+if EXIST "%EXAMPLES_HOME%" (
+    @echo Delete existing %EXAMPLES_HOME% ...
+    rd /s /q "%EXAMPLES_HOME%"
+)
+if NOT EXIST "%EXAMPLES_HOME%" mkdir "%EXAMPLES_HOME%"
+
+set CURRDIR=%cd%
+for /f "delims=" %%D in ('dir /b /s bin') do call :copyexamples %%D
+goto :copyscripts
+
+:copyexamples
+    set EXAMPLES_SRC=%1
+    set EXAMPLES_TARGET=%1
+    call set EXAMPLES_TARGET=%%EXAMPLES_TARGET:%CURRDIR%=%EXAMPLES_HOME%%%
+    set EXAMPLES_TARGET=%EXAMPLES_TARGET:~0,-3%
+
+    @echo mkdir %EXAMPLES_TARGET%
+    if NOT EXIST "%EXAMPLES_TARGET%" mkdir "%EXAMPLES_TARGET%"
+    copy /y "%EXAMPLES_SRC%\Release\*" "%EXAMPLES_TARGET%"
+    goto :eof
+
+:copyscripts
 popd
 
 @echo Assemble SparkCLR script components
@@ -150,8 +176,8 @@ if not defined ProjectVersion (
 set SPARKCLR_NAME=spark-clr_2.10-%ProjectVersion%
 
 @rem Create the zip file
-@echo 7z a .\target\%SPARKCLR_NAME%.zip runtime localmode ..\examples
-7z a .\target\%SPARKCLR_NAME%.zip runtime localmode ..\examples
+@echo 7z a .\target\%SPARKCLR_NAME%.zip runtime localmode examples
+7z a .\target\%SPARKCLR_NAME%.zip runtime localmode examples
 
 :distdone
 popd


### PR DESCRIPTION
The release zip file includes source files under "examples" folder. the fix is to include examples binaries in release zip file.

Refer to #289 