### PR TITLE
Fix build failure of Examples.sln for branch-1.6

### DIFF
--- a/examples/Sql/JdbcDataFrame/JdbcDataFrame.csproj
+++ b/examples/Sql/JdbcDataFrame/JdbcDataFrame.csproj
@@ -35,13 +35,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CSharpWorker">
-      <HintPath>..\packages\Microsoft.SparkCLR.1.6.000-PREVIEW-2\lib\net45\CSharpWorker.exe</HintPath>
+      <HintPath>..\..\packages\Microsoft.SparkCLR.1.6.000-PREVIEW-2\lib\net45\CSharpWorker.exe</HintPath>
     </Reference>
     <Reference Include="log4net">
       <HintPath>..\..\packages\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Spark.CSharp.Adapter">
-      <HintPath>..\packages\Microsoft.SparkCLR.1.6.000-PREVIEW-2\lib\net45\Microsoft.Spark.CSharp.Adapter.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.SparkCLR.1.6.000-PREVIEW-2\lib\net45\Microsoft.Spark.CSharp.Adapter.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/examples/Sql/SparkXml/SparkXml.csproj
+++ b/examples/Sql/SparkXml/SparkXml.csproj
@@ -35,12 +35,12 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CSharpWorker">
-      <HintPath>..\packages\Microsoft.SparkCLR.1.6.000-PREVIEW-2\lib\net45\CSharpWorker.exe</HintPath>
+      <HintPath>..\..\packages\Microsoft.SparkCLR.1.6.000-PREVIEW-2\lib\net45\CSharpWorker.exe</HintPath>
     </Reference>
     <Reference Include="log4net">
       <HintPath>..\..\packages\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Spark.CSharp.Adapter">>
+    <Reference Include="Microsoft.Spark.CSharp.Adapter">
       <HintPath>..\..\packages\Microsoft.SparkCLR.1.6.000-PREVIEW-2\lib\net45\Microsoft.Spark.CSharp.Adapter.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
@@ -61,7 +61,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\packages\Microsoft.SparkCLR.1.6.000-PREVIEW-2\lib\net45\CSharpWorker.exe.config">
+    <None Include="..\..\packages\Microsoft.SparkCLR.1.6.000-PREVIEW-2\lib\net45\CSharpWorker.exe.config">
       <Link>CSharpWorker.exe.config</Link>
     </None>
     <None Include="App.config" />

--- a/examples/Streaming/EventHub/EventHub.csproj
+++ b/examples/Streaming/EventHub/EventHub.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <Reference Include="CSharpWorker">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.SparkCLR.1.6.000-PREVIEW-2\lib\net45\CSharpWorker.exe</HintPath>
+      <HintPath>..\..\packages\Microsoft.SparkCLR.1.6.000-PREVIEW-2\lib\net45\CSharpWorker.exe</HintPath>
     </Reference>
     <Reference Include="log4net">
       <HintPath>..\..\packages\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
@@ -67,7 +67,7 @@
     <Compile Include="EventPublisher.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\packages\Microsoft.SparkCLR.1.6.000-PREVIEW-2\lib\net45\CSharpWorker.exe.config">
+    <None Include="..\..\packages\Microsoft.SparkCLR.1.6.000-PREVIEW-2\lib\net45\CSharpWorker.exe.config">
       <Link>CSharpWorker.exe.config</Link>
     </None>
     <None Include="App.config">


### PR DESCRIPTION
Examples.sln build failed on branch-1.6 due to the wrong reference of Mobius preview in csproj files