### PR TITLE
Fix Build.cmd to stop building when Examples compiling failed

### DIFF
--- a/build/Build.cmd
+++ b/build/Build.cmd
@@ -134,6 +134,12 @@ pushd "%CMDHOME%\..\examples"
 call Clean.cmd
 call Build.cmd
 
+if %ERRORLEVEL% NEQ 0 (
+  @echo Build SparkCLR C# examples failed, stop building.
+  popd
+  goto :eof
+)
+
 set EXAMPLES_HOME=%CMDHOME%\examples
 @echo set EXAMPLES_HOME=%EXAMPLES_HOME%
 


### PR DESCRIPTION
Currently, the build process cannot be stopped if Examples solution has compiling failure. The fix is to stop building process if Examples failed.