### PR TITLE
renamed mobius config names

### DIFF
--- a/scala/src/main/org/apache/spark/api/csharp/CSharpRDD.scala
+++ b/scala/src/main/org/apache/spark/api/csharp/CSharpRDD.scala
@@ -60,7 +60,7 @@ class CSharpRDD(
       command(i) = bytes(i)
     }
 
-    if (CSharpRDD.maxCSharpWorkerNum >= 0) {
+    if (CSharpRDD.maxCSharpWorkerProcessCount >= 0) {
       var workerFactoryId = CSharpRDD.getWorkerFactoryId(context.stageId())
       // change envVars to use different PythonWorkerFactory
       envVars.put("WORKER_FACTORY_ID", workerFactoryId.toString)
@@ -191,8 +191,8 @@ object CSharpRDD {
   var currentStageId: Int = 0
   var nextSeqNum: Int = 0
 
-  // long runing multi-process CSharpWorker mode is enabled only when configurated explicitly
-  var maxCSharpWorkerNum: Int = SparkEnv.get.conf.getInt("spark.csharp.worker.maxNum", -1)
+  // long running multi-process CSharpWorker mode is enabled only when configurated explicitly
+  var maxCSharpWorkerProcessCount: Int = SparkEnv.get.conf.getInt("spark.mobius.CSharpWorker.maxProcessCount", -1)
 
   def createRDDFromArray(
       sc: SparkContext,
@@ -225,8 +225,8 @@ object CSharpRDD {
         nextSeqNum = 0
       }
       val workerFactoryId = {
-        if (maxCSharpWorkerNum != 0) {
-          nextSeqNum % maxCSharpWorkerNum
+        if (maxCSharpWorkerProcessCount != 0) {
+          nextSeqNum % maxCSharpWorkerProcessCount
         } else {
           nextSeqNum
         }

--- a/scala/src/main/org/apache/spark/streaming/api/kafka/DynamicPartitionKafkaRDD.scala
+++ b/scala/src/main/org/apache/spark/streaming/api/kafka/DynamicPartitionKafkaRDD.scala
@@ -90,7 +90,7 @@ class DynamicPartitionKafkaRDD[
       s"for topic ${part.topic} partition ${part.partition} start ${part.fromOffset}." +
       " This should not happen, and indicates a message may have been skipped"
 
-  private val CSharpReaderEnabled: Boolean = sc.getConf.getBoolean("mobius.streaming.kafka.CSharpReader.enabled", false)
+  private val CSharpReaderEnabled: Boolean = sc.getConf.getBoolean("spark.mobius.streaming.kafka.CSharpReader.enabled", false)
 
   override def compute(thePart: Partition, context: TaskContext): Iterator[R] = {
     val part = thePart.asInstanceOf[KafkaRDDPartition]

--- a/scala/src/main/org/apache/spark/streaming/api/kafka/DynamicPartitionKafkaRDD.scala
+++ b/scala/src/main/org/apache/spark/streaming/api/kafka/DynamicPartitionKafkaRDD.scala
@@ -51,7 +51,7 @@ class DynamicPartitionKafkaRDD[
       if (numPartitions < 0) {
         // If numPartitions = -1, either repartition based on spark.streaming.kafka.maxRatePerTask.*
         // or do nothing if config not defined
-        (topic, sparkContext.getConf.getInt("spark.streaming.kafka.maxRatePerTask." + topic,
+        (topic, sparkContext.getConf.getInt("spark.mobius.streaming.kafka.maxMessagesPerTask." + topic,
           Int.MaxValue).asInstanceOf[Long])
       } else {
         val partitions = {

--- a/scala/src/test/scala/org/apache/spark/streaming/api/kafka/DynamicPartitionKafkaRDDSuite.scala
+++ b/scala/src/test/scala/org/apache/spark/streaming/api/kafka/DynamicPartitionKafkaRDDSuite.scala
@@ -75,8 +75,8 @@ class DynamicPartitionKafkaRDDSuite extends SparkCLRFunSuite {
       )
       assert(testEqualityOfKafkaPartitions(partitions, rdd.getPartitions))
 
-      // test numPartitions < 0, with spark.streaming.kafka.maxRatePerTask.* conf
-      sc.conf.set("spark.streaming.kafka.maxRatePerTask." + topic, "500")
+      // test numPartitions < 0, with spark.mobius.streaming.kafka.maxMessagesPerTask.* conf
+      sc.conf.set("spark.mobius.streaming.kafka.maxMessagesPerTask." + topic, "500")
       rdd = new DynamicPartitionKafkaRDD(sc, Map(), offsetRanges, leaders, null, -1)
       partitions = Array(
         new KafkaRDDPartition(0, topic, 0, 100, 600, host0, port),


### PR DESCRIPTION
Spark config parsing ignores configs that do not have "spark." prefix