### PR TITLE
Fix error in csharp/nuget.config

### DIFF
--- a/csharp/nuget.config
+++ b/csharp/nuget.config
@@ -1,3 +1,6 @@
-<settings>
-  <repositoryPath>packages</repositoryPath>
-</settings>
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <settings>
+    <repositoryPath>packages</repositoryPath>
+  </settings>
+</configuration>


### PR DESCRIPTION
Fix error in csharp/nuget.config file.

Failure mode is:

```
===== Build NuGet package for E:\Depot\GitHub\SparkCLR\csharp\SparkCLR.sln =====
[nugetpack.ps1] [INFO] tagname=[]
NuGet.Config does not contain the expected root element: 'configuration'. 
Path: 'E:\Depot\GitHub\SparkCLR\csharp\NuGet.Config'.
```

PR #404 exposed this issue, but the underlying problem predates that.