### PR TITLE
Avoid unnecessary CSharpRDD if the same partitioner is used in Partit…

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Core/PairRDDFunctions.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Core/PairRDDFunctions.cs
@@ -310,7 +310,7 @@ namespace Microsoft.Spark.CSharp.Core
             }
             
             var partitioner = new Partitioner(numPartitions, partitionFunc);
-            if (self.partitioner == partitioner)
+            if (self.partitioner != null && self.partitioner.Equals(partitioner))
                 return self;
 
             var keyed = self.MapPartitionsWithIndex(new AddShuffleKeyHelper<K, V>(numPartitions, partitionFunc).Execute, true);


### PR DESCRIPTION
This will reduce one CSharpRDD in UpdateStateByKey stage in SML pipeline.