### PR TITLE
Fixing refreshOffsetsScheduler do not start scheduling tasks issue

### DIFF
--- a/scala/src/main/org/apache/spark/streaming/api/kafka/DynamicPartitionKafkaInputDStream.scala
+++ b/scala/src/main/org/apache/spark/streaming/api/kafka/DynamicPartitionKafkaInputDStream.scala
@@ -291,9 +291,7 @@ class DynamicPartitionKafkaInputDStream[
   }
 
   override def start(): Unit = {
-    if(refreshOffsetsScheduler == null) {
-      instantiateAndStartRefreshOffsetsScheduler
-    }
+    instantiateAndStartRefreshOffsetsScheduler
   }
 
   override def stop(): Unit = {


### PR DESCRIPTION
In current implementation, `refreshOffsetsScheduler` is started to schedule `setOffsetsRangeForNextBatch` task in `instantiateAndStartRefreshOffsetsScheduler`.
However, in `start()` method, `refreshOffsetsScheduler` is not null for a refresh start(not restoring from checkpoint), so `refreshOffsetsScheduler` has no chance to start scheduling by calling `scheduleAtFixedRate`