### PR TITLE
Fixing unary operator error in Linux build scripts

### DIFF
--- a/csharp/build.sh
+++ b/csharp/build.sh
@@ -4,7 +4,7 @@ export FWDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export XBUILDOPT=/verbosity:minimal
 
-if [ $builduri = "" ];
+if [ -z $builduri ];
 then
   export builduri=build.sh
 fi
@@ -15,7 +15,7 @@ export PROJ="$FWDIR/$PROJ_NAME.sln"
 echo "===== Building $PROJ ====="
 
 function error_exit() {
-  if [ "$STEP" = "" ]; 
+  if [ -z $STEP ]; 
   then
     export STEP=$CONFIGURATION 
   fi

--- a/examples/build.sh
+++ b/examples/build.sh
@@ -4,7 +4,7 @@ export FWDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export XBUILDOPT=/verbosity:minimal
 
-if [ $builduri = "" ];
+if [ -z $builduri ];
 then
   export builduri=build.sh
 fi
@@ -15,7 +15,7 @@ export PROJ="$FWDIR/$PROJ_NAME.sln"
 echo "===== Building $PROJ ====="
 
 function error_exit() {
-  if [ "$STEP" = "" ]; 
+  if [ -z $STEP ]; 
   then
     export STEP=$CONFIGURATION 
   fi


### PR DESCRIPTION
Empty strings should be checked with `[ -z $foo ]` instead of `[ $foo = "" ]` 🎉 