### PR TITLE
Fix error passing arguments of sparkclr-submit to spark-submit when arguments contain special characters.

### DIFF
--- a/scala/src/test/scala/org/apache/spark/launcher/SparkCLRSubmitArgumentsSuite.scala
+++ b/scala/src/test/scala/org/apache/spark/launcher/SparkCLRSubmitArgumentsSuite.scala
@@ -406,4 +406,19 @@ class SparkCLRSubmitArgumentsSuite extends SparkCLRFunSuite with Matchers with T
         " " +
         args.mkString(" ")
   }
+
+  test("Quote command line args test") {
+    def SameAfterQuoted(arg: String, addNeedlessQuote: Boolean = false): Boolean = {
+      val quoted = SparkCLRSubmitArguments.quoteArg(arg, addNeedlessQuote)
+      quoted == arg
+    }
+
+    SameAfterQuoted("jdbc:mysql://localhost:3306/lzdb?user=guest&password=abc123") shouldBe (false)
+    SameAfterQuoted("jdbc:sqlserver://127.0.0.1:1433;databaseName=lzdb;user=guest;password=abc123") shouldBe (false)
+    SameAfterQuoted("not-need_quote") shouldBe (true)
+    SameAfterQuoted("not-need-quote", true) shouldBe (false)
+    SameAfterQuoted("need quote has spaces") shouldBe (false)
+    SameAfterQuoted("need quote has special char^") shouldBe (false)
+    SameAfterQuoted("not-need-as-acceptable-chars-.:/") shouldBe (true)
+  }
 }


### PR DESCRIPTION
Fix error passing arguments of sparkclr-submit to spark-submit when arguments contain special characters.

for example : an arg is a connection string as following :
"jdbc:mysql://localhost:3306/lzdb?user=guest&password=abc123"
it contains "&" , cannot pass it from sparkclr-submit.cmd to spark-submit.cmd, even if you quote it like above. 

Error happens in script : https://github.com/Microsoft/Mobius/blob/master/scripts/sparkclr-submit.cmd#L62
The quote (if you added) will disappear in file  LAUNCHER_OUTPUT.
