### PR TITLE
Add F# documentation and Maven version data

### DIFF
--- a/notes/linux-instructions.md
+++ b/notes/linux-instructions.md
@@ -3,8 +3,9 @@
 ## Prerequisites
 
 * JDK 7 or above.
-* Maven 3.3.3 or above.
+* Maven 3.0.5 or above.
 * Mono 4.2 stable or above. The download and installation instructions for Mono are available in [http://www.mono-project.com/download/#download-lin](http://www.mono-project.com/download/#download-lin).
+* F# for Mono. The download and installation instructions for the F# Mono extension are available in [http://fsharp.org/use/linux/](http://fsharp.org/use/linux/)
 * NuGet.
 * XSLTPROC
 


### PR DESCRIPTION
F# documentation to allow F# work count example to compile under build step.  Also version of Maven that is standard in the Debian repository, therefore which is pulled by apt for Debian, Ubuntu, Mint, etc. is 3.0.5 not 3.3.x.  I had no problems running any of the scripts with that version of Maven.