### PR TITLE
Add option to turn on/off local checkpoint for CSharpStateDStream

### DIFF
--- a/notes/configuration-mobius.md
+++ b/notes/configuration-mobius.md
@@ -4,5 +4,5 @@
 |Worker  |spark.mobius.CSharpWorker.maxProcessCount  |Sets max number of C# worker processes in Spark executors |
 |Streaming (Kafka)  |spark.mobius.streaming.kafka.CSharpReader.enabled  |Enables use of C# Kafka reader in Mobius streaming applications |
 |Streaming (Kafka)  |spark.mobius.streaming.kafka.maxMessagesPerTask.&lt;topicName&gt;  |Sets the max number of messages per RDD partition created from specified Kafka topic to uniformly spread load across tasks that process them  |
-
-
+|Streaming (Checkpoint)  |spark.mobius.streaming.localCheckpoint.enabled  | Enables `CSharpStateDStream` to use  `RDD.localCheckpoint()`  instead of `RDD.checkpoint()` for checkpointing  |
+|Streaming (Checkpoint)  |spark.mobius.streaming.localCheckpoint.replicas  | When `spark.mobius.streaming.localCheckpoint.enabled` is set to `true`, specify the number of replicas for each block |

--- a/scala/src/main/org/apache/spark/streaming/api/csharp/CSharpDStream.scala
+++ b/scala/src/main/org/apache/spark/streaming/api/csharp/CSharpDStream.scala
@@ -25,6 +25,10 @@ import scala.language.existentials
 
 object CSharpDStream {
 
+  // Variables for debugging
+  var debugMode = false
+  var debugRDD: Option[RDD[_]] = None
+
   /**
    * helper function for DStream.foreachRDD().
    */
@@ -38,6 +42,11 @@ object CSharpDStream {
 
   def callCSharpTransform(rdds: List[Option[RDD[_]]], time: Time, cSharpfunc: Array[Byte],
                           serializationModeList: List[String]): Option[RDD[Array[Byte]]] = {
+    //debug mode enabled
+    if(debugMode) {
+      return debugRDD.asInstanceOf[Option[RDD[Array[Byte]]]]
+    }
+
     var socket: Socket = null
     try {
       socket = CSharpBackend.callbackSockets.poll()
@@ -224,11 +233,11 @@ class CSharpStateDStream(
                           serializationMode2: String)
   extends DStream[Array[Byte]](parent.ssc) {
 
-  val localCheckpointEnabled = parent.ssc.sc.conf.getBoolean("spark.mobius.localCheckpoint.enabled", false)
+  val localCheckpointEnabled = parent.ssc.sc.conf.getBoolean("spark.mobius.streaming.localCheckpoint.enabled", false)
   logInfo("Local checkpoint is enabled: " + localCheckpointEnabled)
 
   if(localCheckpointEnabled) {
-    val replicas = parent.ssc.sc.conf.getInt("spark.mobius.localCheckpoint.replicas", 3)
+    val replicas = parent.ssc.sc.conf.getInt("spark.mobius.streaming.localCheckpoint.replicas", 3)
     logInfo("spark.mobius.localCheckpoint.replicas is set to " + replicas)
     super.persist(StorageLevel(true, true, false, false, replicas))
   }else {

--- a/scala/src/test/scala/org/apache/spark/streaming/api/csharp/CSharpDStreamSuite.scala
+++ b/scala/src/test/scala/org/apache/spark/streaming/api/csharp/CSharpDStreamSuite.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package org.apache.spark.streaming.api.csharp
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.csharp.SparkCLRFunSuite
+import org.apache.spark.rdd.LocalRDDCheckpointData
+import org.apache.spark.streaming._
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+
+import scala.collection.mutable._
+
+class CSharpDStreamSuite extends SparkCLRFunSuite with BeforeAndAfterAll with BeforeAndAfter {
+  private var conf: SparkConf = null
+  private var sc: SparkContext = null
+
+  before {
+    StreamingContext.getActive().foreach { _.stop(stopSparkContext = false) }
+  }
+
+  after {
+    StreamingContext.getActive().foreach { _.stop(stopSparkContext = false) }
+  }
+
+  override def afterAll(): Unit = {
+    if (sc != null) {
+      sc.stop()
+    }
+  }
+
+  test("CSharpStateDStream - local checkpoint enabled") {
+    val replicas = 2
+    conf = new SparkConf().setMaster("local[*]").setAppName("CSharpStateDStream")
+    conf.set("spark.mobius.streaming.localCheckpoint.enabled", "true")
+    conf.set("spark.mobius.streaming.localCheckpoint.replicas", replicas.toString)
+
+    sc = new SparkContext(conf)
+    val ssc = new StreamingContext(sc, Seconds(1))
+
+    // Set up CSharpDStream
+    val expectedRDD = sc.makeRDD(ArrayBuffer.fill(10)("a".getBytes))
+    CSharpDStream.debugMode = true
+    CSharpDStream.debugRDD = Some(expectedRDD)
+
+    // Construct CSharpStateDStream
+    val parentDStream = ssc.queueStream[Array[Byte]](Queue(sc.makeRDD(ArrayBuffer.fill(10)("a".getBytes))), true)
+    val stateDStream = new CSharpStateDStream(parentDStream, new Array[Byte](0), "byte", "byte")
+    stateDStream.register()
+
+    val rddCount = new AtomicInteger(0) // counter to indicate how many batches have finished
+
+    stateDStream.foreachRDD { stateRDD =>
+      rddCount.incrementAndGet()
+      println(stateRDD.count())
+      // asserts
+      assert(stateRDD.checkpointData.get.isInstanceOf[LocalRDDCheckpointData[Array[Byte]]])
+      assert(stateRDD.getStorageLevel.replication == replicas)
+    }
+    ssc.start()
+
+    // check whether first batch finished
+    val startWaitingTimeInMills = System.currentTimeMillis()
+    val maxWaitingTimeInSecs = 20
+    while(rddCount.get() < 1) {
+      Thread.sleep(100)
+      if((System.currentTimeMillis() - startWaitingTimeInMills) > maxWaitingTimeInSecs * 1000) {
+        // if waiting time exceeds `maxWaitingTimeInSecs` secs, will fail current test.
+        fail(s"Total running time exceeds $maxWaitingTimeInSecs, fail current test.")
+      }
+    }
+
+    ssc.stop(false)
+    assert(rddCount.get() >= 1)
+  }
+}

--- a/scala/src/test/scala/org/apache/spark/streaming/api/csharp/CSharpDStreamSuite.scala
+++ b/scala/src/test/scala/org/apache/spark/streaming/api/csharp/CSharpDStreamSuite.scala
@@ -39,6 +39,9 @@ class CSharpDStreamSuite extends SparkCLRFunSuite with BeforeAndAfterAll with Be
     conf.set("spark.mobius.streaming.localCheckpoint.enabled", "true")
     conf.set("spark.mobius.streaming.localCheckpoint.replicas", replicas.toString)
 
+    // set reserved memory to 50M so the min system memory only needs 50M * 1.5 = 70.5M
+    conf.set("spark.testing.reservedMemory", "" + 50 * 1024 * 1024)
+
     sc = new SparkContext(conf)
     val ssc = new StreamingContext(sc, Seconds(1))
 


### PR DESCRIPTION
Code change in this PR is based on @xiongrenyi 's code changes. This PR adds two options to control whether enable/disable local checkpoint for `CSharpStateDStream`.
* `spark.mobius.streaming.localCheckpoint.enabled`
 * When set to `true`, `CSharpStateDStream` uses `RDD.localCheckpoint()` instead of normal `RDD.checkpoint()`, for differences between them please refer to https://spark.apache.org/docs/latest/api/java/org/apache/spark/rdd/RDD.html#localCheckpoint()
https://spark.apache.org/docs/latest/api/java/org/apache/spark/rdd/RDD.html#checkpoint()

* `spark.mobius.streaming.localCheckpoint.replicas`  
 * specify how many replicas are needed for each block.

Unit test for this change is also included.