### PR TITLE
Fixing issue that build did not stop when mvn build failed

### DIFF
--- a/build/Build.cmd
+++ b/build/Build.cmd
@@ -79,12 +79,14 @@ IF "%APPVEYOR_REPO_TAG%" == "true" (goto :sign)
 
 :mvndone
 
+set MVN_ERRORLEVEL=%ERRORLEVEL%
+
 @rem
 @rem After uber package is created, restore Pom.xml
 @rem
 copy /y %temp%\pom.xml.original pom.xml
 
-if %ERRORLEVEL% NEQ 0 (
+if %MVN_ERRORLEVEL% NEQ 0 (
   @echo Build Mobius Scala components failed, stop building.
   popd
   goto :eof


### PR DESCRIPTION
* `copy` operation overwrites `%ERRORLEVEL%` returned by `mvn.cmd build`, which caused build script failed to check whether scala build succeed or not.

* This PR tries to saves `%ERRORLEVEL%` to a variable `MVN_ERRORLEVEL` before do any other operations, and use this variable to check mvn build status.