### PR TITLE
Operator updateStateByKey supports initial state RDD

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Streaming/PairDStreamFunctions.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Streaming/PairDStreamFunctions.cs
@@ -319,13 +319,14 @@ namespace Microsoft.Spark.CSharp.Streaming
         ///     State update function - (newValues, oldState) => newState
         ///     If this function returns None, then corresponding state key-value pair will be eliminated.
         /// </param>
+        /// <param name="initialState">Initial state value of each key</param>
         /// <param name="numPartitions"></param>
         /// <returns></returns>
         public static DStream<KeyValuePair<K, S>> UpdateStateByKey<K, V, S>(this DStream<KeyValuePair<K, V>> self,
-            Func<IEnumerable<V>, S, S> updateFunc,
+            Func<IEnumerable<V>, S, S> updateFunc, RDD<KeyValuePair<K, S>> initialState = null,
             int numPartitions = 0)
         {
-            return UpdateStateByKey<K, V, S>(self, new UpdateStateByKeyHelper<K, V, S>(updateFunc).Execute, numPartitions);
+            return UpdateStateByKey<K, V, S>(self, new UpdateStateByKeyHelper<K, V, S>(updateFunc).Execute, initialState, numPartitions);
         }
         
         /// <summary>
@@ -337,13 +338,14 @@ namespace Microsoft.Spark.CSharp.Streaming
         /// <typeparam name="S"></typeparam>
         /// <param name="self"></param>
         /// <param name="updateFunc">State update function - IEnumerable[K, [newValues, oldState]] => IEnumerable[K, newState]</param>
+        /// <param name="initialState">Initial state value of each key</param>
         /// <param name="numPartitions"></param>
         /// <returns></returns>
         public static DStream<KeyValuePair<K, S>> UpdateStateByKey<K, V, S>(this DStream<KeyValuePair<K, V>> self,
-            Func<IEnumerable<KeyValuePair<K, Tuple<IEnumerable<V>, S>>>, IEnumerable<KeyValuePair<K, S>>> updateFunc,
+            Func<IEnumerable<KeyValuePair<K, Tuple<IEnumerable<V>, S>>>, IEnumerable<KeyValuePair<K, S>>> updateFunc, RDD<KeyValuePair<K, S>> initialState = null,
             int numPartitions = 0)
         {
-            return UpdateStateByKey<K, V, S>(self, new MapPartitionsHelper<KeyValuePair<K, Tuple<IEnumerable<V>, S>>, KeyValuePair<K, S>>(updateFunc).Execute, numPartitions);
+            return UpdateStateByKey<K, V, S>(self, new MapPartitionsHelper<KeyValuePair<K, Tuple<IEnumerable<V>, S>>, KeyValuePair<K, S>>(updateFunc).Execute, initialState, numPartitions);
         }
         
         /// <summary>
@@ -355,18 +357,19 @@ namespace Microsoft.Spark.CSharp.Streaming
         /// <typeparam name="S"></typeparam>
         /// <param name="self"></param>
         /// <param name="updateFunc">State update function - (pid, IEnumerable[K, [newValues, oldState]]) => IEnumerable[K, newState]</param>
+        /// <param name="initialState">Initial state value of each key</param>
         /// <param name="numPartitions"></param>
         /// <returns></returns>
         public static DStream<KeyValuePair<K, S>> UpdateStateByKey<K, V, S>(this DStream<KeyValuePair<K, V>> self,
             Func<int, IEnumerable<KeyValuePair<K, Tuple<IEnumerable<V>, S>>>, IEnumerable<KeyValuePair<K, S>>> updateFunc,
-            int numPartitions = 0)
+            RDD<KeyValuePair<K, S>> initialState = null, int numPartitions = 0)
         {
             if (numPartitions <= 0)
                 numPartitions = self.streamingContext.SparkContext.DefaultParallelism;
 
             Func<double, RDD<dynamic>, RDD<dynamic>> prevFunc = self.Piplinable ? (self as TransformedDStream<KeyValuePair<K, V>>).func : null;
 
-            Func<double, RDD<dynamic>, RDD<dynamic>, RDD<dynamic>> func = new UpdateStateByKeysHelper<K, V, S>(updateFunc, prevFunc, numPartitions).Execute;
+            Func<double, RDD<dynamic>, RDD<dynamic>, RDD<dynamic>> func = new UpdateStateByKeysHelper<K, V, S>(updateFunc, prevFunc, initialState, numPartitions).Execute;
 
             var formatter = new BinaryFormatter();
             var stream = new MemoryStream();
@@ -656,13 +659,15 @@ namespace Microsoft.Spark.CSharp.Streaming
     {
         private readonly Func<int, IEnumerable<KeyValuePair<K, Tuple<IEnumerable<V>, S>>>, IEnumerable<KeyValuePair<K, S>>> func;
         private readonly Func<double, RDD<dynamic>, RDD<dynamic>> prevFunc;
+        private readonly RDD<KeyValuePair<K, S>> initialState;
         private readonly int numPartitions;
         internal UpdateStateByKeysHelper(
             Func<int, IEnumerable<KeyValuePair<K, Tuple<IEnumerable<V>, S>>>, IEnumerable<KeyValuePair<K, S>>> f, 
-            Func<double, RDD<dynamic>, RDD<dynamic>> prevF, int numPartitions)
+            Func<double, RDD<dynamic>, RDD<dynamic>> prevF, RDD<KeyValuePair<K, S>> initialState, int numPartitions)
         {
             func = f;
             prevFunc = prevF;
+            this.initialState = initialState;
             this.numPartitions = numPartitions;
         }
 
@@ -675,6 +680,18 @@ namespace Microsoft.Spark.CSharp.Streaming
                 valuesRDD = prevFunc(t, valuesRDD);
 
             var values = valuesRDD.ConvertTo<KeyValuePair<K, V>>();
+
+            if (stateRDD == null)
+            {
+                if (initialState != null)
+                {
+                    if (initialState.sparkContext == null)
+                    {
+                        initialState.sparkContext = valuesRDD.sparkContext;
+                    }
+                    stateRDD = initialState.ConvertTo<dynamic>();
+                }
+            }
 
             if (stateRDD == null)
             {

--- a/csharp/AdapterTest/DStreamTest.cs
+++ b/csharp/AdapterTest/DStreamTest.cs
@@ -285,6 +285,20 @@ namespace AdapterTest
                     Assert.AreEqual(countByWord.Key == "The" || countByWord.Key == "dog" || countByWord.Key == "lazy" ? 23 : 22, countByWord.Value);
                 }
             });
+
+            // test when initialStateRdd is not provided
+            var state2 = pairs.UpdateStateByKey<string, int, int>((v, s) => s + (v as List<int>).Count);
+            state2.ForeachRDD((time, rdd) =>
+            {
+                var taken = rdd.Collect();
+                Assert.AreEqual(taken.Length, 9);
+
+                foreach (object record in taken)
+                {
+                    KeyValuePair<string, int> countByWord = (KeyValuePair<string, int>)record;
+                    Assert.AreEqual(countByWord.Key == "The" || countByWord.Key == "dog" || countByWord.Key == "lazy" ? 23 : 22, countByWord.Value);
+                }
+            });
         }
 
         [Test]

--- a/csharp/AdapterTest/DStreamTest.cs
+++ b/csharp/AdapterTest/DStreamTest.cs
@@ -272,16 +272,17 @@ namespace AdapterTest
             // disable pipeline to UpdateStateByKey which replys on checkpoint mock proxy doesn't support
             pairs.Cache();
 
-            var state = pairs.UpdateStateByKey<string, int, int>((v, s) => s + (v as List<int>).Count);
+            var initialStateRdd = ssc.SparkContext.Parallelize(new[] { "AAA" }).Map( w => new KeyValuePair<string, int>("AAA", 22));
+            var state = pairs.UpdateStateByKey<string, int, int>((v, s) => s + (v as List<int>).Count, initialStateRdd);
             state.ForeachRDD((time, rdd) =>
             {
                 var taken = rdd.Collect();
-                Assert.AreEqual(taken.Length, 9);
+                Assert.AreEqual(taken.Length, 10);
 
                 foreach (object record in taken)
                 {
                     KeyValuePair<string, int> countByWord = (KeyValuePair<string, int>)record;
-                    Assert.AreEqual(countByWord.Value, countByWord.Key == "The" || countByWord.Key == "dog" || countByWord.Key == "lazy" ? 24 : 23);
+                    Assert.AreEqual(countByWord.Key == "The" || countByWord.Key == "dog" || countByWord.Key == "lazy" ? 23 : 22, countByWord.Value);
                 }
             });
         }

--- a/csharp/AdapterTest/Mocks/MockRddProxy.cs
+++ b/csharp/AdapterTest/Mocks/MockRddProxy.cs
@@ -18,6 +18,7 @@ using NUnit.Framework;
 
 namespace AdapterTest.Mocks
 {
+    [Serializable]
     internal class MockRddProxy : IRDDProxy
     {
         internal IEnumerable<dynamic> result;

--- a/csharp/AdapterTest/Mocks/MockStreamingContextProxy.cs
+++ b/csharp/AdapterTest/Mocks/MockStreamingContextProxy.cs
@@ -103,7 +103,7 @@ namespace AdapterTest.Mocks
         {
             Func<double, RDD<dynamic>, RDD<dynamic>, RDD<dynamic>> f = (Func<double, RDD<dynamic>, RDD<dynamic>, RDD<dynamic>>)formatter.Deserialize(new MemoryStream(func));
             RDD<dynamic> rdd = f(DateTime.UtcNow.Ticks,
-                new RDD<dynamic>((jdstream as MockDStreamProxy).rddProxy ?? new MockRddProxy(null), new SparkContext("", "")),
+                null,
                 new RDD<dynamic>((jdstream as MockDStreamProxy).rddProxy ?? new MockRddProxy(null), new SparkContext("", "")));
             return new MockDStreamProxy(rdd.RddProxy);
         }

--- a/csharp/Samples/Microsoft.Spark.CSharp/DStreamSamples.cs
+++ b/csharp/Samples/Microsoft.Spark.CSharp/DStreamSamples.cs
@@ -82,7 +82,8 @@ namespace Microsoft.Spark.CSharp
                     // an extra CSharpRDD is introduced in between these operations
                     var wordCounts = pairs.ReduceByKey((x, y) => x + y);
                     var join = wordCounts.Window(2, 2).Join(wordCounts, 2);
-                    var state = join.UpdateStateByKey<string, Tuple<int, int>, int>(new UpdateStateHelper(b).Execute);
+                    var initialStateRdd = sc.Parallelize( new[] {new KeyValuePair<string, int>("AAA", 88), new KeyValuePair<string, int>("BBB", 88)});
+                    var state = join.UpdateStateByKey(new UpdateStateHelper(b).Execute, initialStateRdd);
 
                     state.ForeachRDD((time, rdd) =>
                     {


### PR DESCRIPTION
* By default Spark `updateStateByKey` supports parameter `initialRDD` [[link](https://github.com/apache/spark/blob/master/streaming/src/main/scala/org/apache/spark/streaming/dstream/PairDStreamFunctions.scala#L475)], which represents the initial state value of each key.

* Add this parameter to Mobius `UpdateStateByKey()`