### PR TITLE
Release JVM object reference in Java(Scala) side JVMObjectTracker from C# side.

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Adapter.csproj
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Adapter.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Core\StorageLevel.cs" />
     <Compile Include="Interop\Ipc\JsonSerDe.cs" />
     <Compile Include="Interop\Ipc\JvmBridgeUtils.cs" />
+    <Compile Include="Interop\Ipc\WeakObjectManager.cs" />
     <Compile Include="Interop\SparkCLREnvironment.cs" />
     <Compile Include="Interop\Ipc\IJvmBridge.cs" />
     <Compile Include="Interop\Ipc\JvmBridge.cs" />

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Interop/Ipc/JvmObjectReference.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Interop/Ipc/JvmObjectReference.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Spark.CSharp.Interop.Ipc
         {
             Id = jvmReferenceId;
             creationTime = DateTime.UtcNow;
+            WeakObjectManager.GetWeakObjectManager().AddWeakRefereceObject(this);
         }
 
         public override string ToString()

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Interop/Ipc/WeakObjectManager.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Interop/Ipc/WeakObjectManager.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Spark.CSharp.Proxy.Ipc;
+
+namespace Microsoft.Spark.CSharp.Interop.Ipc
+{
+    using System.Text.RegularExpressions;
+    using Services;
+
+    using ObjectAndId = KeyValuePair<WeakReference, string>;
+
+    /// <summary>
+    /// Release JVMObjectTracker oject reference.
+    /// The reason is for the inter-operation from CSharp to Java :
+    /// 1.Java-side: https://github.com/Microsoft/Mobius/blob/master/scala/src/main/org/apache/spark/api/csharp/CSharpBackendHandler.scala#L269
+    ///     JVMObjectTracker keep a HashMap[String, Object] which is [id, Java-object]
+    /// 2.CSharp-side :
+    /// 1) JvmObjectReference remember the id : https://github.com/Microsoft/Mobius/blob/master/csharp/Adapter/Microsoft.Spark.CSharp/Interop/Ipc/JvmObjectReference.cs#L20 
+    /// 2) So JvmBridge can call java object's method https://github.com/Microsoft/Mobius/blob/master/csharp/Adapter/Microsoft.Spark.CSharp/Interop/Ipc/JvmBridge.cs#L69
+    /// 
+    /// So potential memory leak can happen in JVMObjectTracker.
+    /// To solve this, track the garbage collection in CSharp side, get the id, release JVMObjectTracker's HashMap. 
+    /// </summary>
+    internal interface IWeakObjectManager : IDisposable
+    {
+        void AddWeakRefereceObject(JvmObjectReference obj);
+    }
+
+    internal class WeakObjectManager : IWeakObjectManager
+    {
+        private const string ReleaseHandler = "SparkCLRHandler";
+        private const string ReleaseMethod = "rm";
+
+        private static readonly ILoggerService logger = LoggerServiceFactory.GetLogger(typeof(WeakObjectManager));
+
+        private ConcurrentQueue<ObjectAndId> weakReferences = new ConcurrentQueue<ObjectAndId>();
+
+        private volatile bool keepRunning = true;
+
+        private const int sleepInterval = 60 * 1000;
+        private static readonly TimeSpan MaxReleasingDuration = TimeSpan.FromMilliseconds(100);
+
+
+        #region Singleton WeakObjectManager
+
+        private static IWeakObjectManager WeakObjManager = new WeakObjectManager();
+
+        public static IWeakObjectManager GetWeakObjectManager()
+        {
+            return WeakObjManager;
+        }
+
+        #endregion
+
+        private WeakObjectManager()
+        {
+            Init();
+        }
+
+        protected void Init()
+        {
+            var thread = new Thread(() =>
+            {
+                logger.LogDebug("Checking objects thread start ...");
+                while (keepRunning)
+                {
+                    CheckReleasedObject();
+                    Thread.Sleep(sleepInterval);
+                }
+
+                logger.LogDebug("Checking objects thread stopped.");
+            });
+
+            thread.IsBackground = true;
+            thread.Start();
+        }
+
+        ~WeakObjectManager()
+        {
+            Dispose();
+        }
+
+        protected void ReleaseObject(string objId)
+        {
+            SparkCLRIpcProxy.JvmBridge.CallStaticJavaMethod(ReleaseHandler, ReleaseMethod, objId);
+        }
+
+        public void AddWeakRefereceObject(JvmObjectReference obj)
+        {
+            if (obj == null || string.IsNullOrEmpty(obj.Id))
+            {
+                logger.LogWarn("Not add null weak object or id : {0}", obj);
+                return;
+            }
+
+            weakReferences.Enqueue(new ObjectAndId(new WeakReference(obj), obj.ToString()));
+        }
+
+        protected void CheckReleasedObject()
+        {
+            if (weakReferences.Count == 0)
+            {
+                logger.LogDebug("CheckReleasedObject begin : weakReferences.Count = {0}", weakReferences.Count);
+                return;
+            }
+
+            var beginTime = DateTime.Now;
+            var endTime = beginTime + MaxReleasingDuration;
+
+            logger.LogDebug("CheckReleasedObject begin : weakReferences.Count = {0}, will stop checking at the latest: {1}", weakReferences.Count, endTime.ToString("yyyy-MM-dd HH:mm:ss.fff"));
+
+            var aliveList = new List<ObjectAndId>();
+            var garbageCount = 0;
+            ObjectAndId refId;
+            while (weakReferences.TryDequeue(out refId))
+            {
+                var weakRef = refId.Key;
+                if (weakRef.IsAlive)
+                {
+                    aliveList.Add(refId);
+                }
+                else
+                {
+                    ReleaseObject(refId.Value);
+                    garbageCount++;
+                }
+
+                if (DateTime.Now > endTime)
+                {
+                    logger.LogDebug("Stop releasing as exceeded allowed time : {0}", endTime.ToString("yyyy-MM-dd HH:mm:ss.fff"));
+                    break;
+                }
+            }
+
+            var timeReleaseGarbage = DateTime.Now;
+            aliveList.ForEach(item => weakReferences.Enqueue(item));
+            var timeStoreAlive = DateTime.Now;
+
+            logger.LogInfo("CheckReleasedObject end : released {0} garbage, remain {1} alive, used {2} ms : release garbage used {3} ms, store alive used {4} ms",
+                    garbageCount, weakReferences.Count, (DateTime.Now - beginTime).TotalMilliseconds,
+                    (timeReleaseGarbage - beginTime).TotalMilliseconds,
+                    (timeStoreAlive - timeReleaseGarbage).TotalMilliseconds
+                );
+        }
+
+        public virtual void Dispose()
+        {
+            logger.LogInfo("Dispose {0}", this.GetType());
+            keepRunning = false;
+        }
+    }
+}

--- a/csharp/SparkCLR.sln
+++ b/csharp/SparkCLR.sln
@@ -23,6 +23,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Utils", "Utils\Microsoft.Sp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.Common", "Tests.Common\Tests.Common.csproj", "{E4479C4C-E106-4B90-BF0C-319561CEA9C4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "testArgsQuotes", "test\testArgsQuotes\testArgsQuotes.csproj", "{CF692E77-8EA9-46EC-BF38-8F7A1BDAFDD0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "testKeyValueStream", "test\testKeyValueStream\testKeyValueStream.csproj", "{E40F7467-A33E-4CCD-841A-EBB14FFB75EF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SourceLinesSocket", "test\SourceLinesSocket\SourceLinesSocket.csproj", "{8BD9D160-77E3-4EB5-9CF6-69D41E5029C0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -61,6 +67,18 @@ Global
 		{E4479C4C-E106-4B90-BF0C-319561CEA9C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E4479C4C-E106-4B90-BF0C-319561CEA9C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E4479C4C-E106-4B90-BF0C-319561CEA9C4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CF692E77-8EA9-46EC-BF38-8F7A1BDAFDD0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF692E77-8EA9-46EC-BF38-8F7A1BDAFDD0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF692E77-8EA9-46EC-BF38-8F7A1BDAFDD0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF692E77-8EA9-46EC-BF38-8F7A1BDAFDD0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E40F7467-A33E-4CCD-841A-EBB14FFB75EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E40F7467-A33E-4CCD-841A-EBB14FFB75EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E40F7467-A33E-4CCD-841A-EBB14FFB75EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E40F7467-A33E-4CCD-841A-EBB14FFB75EF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8BD9D160-77E3-4EB5-9CF6-69D41E5029C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8BD9D160-77E3-4EB5-9CF6-69D41E5029C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8BD9D160-77E3-4EB5-9CF6-69D41E5029C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8BD9D160-77E3-4EB5-9CF6-69D41E5029C0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/csharp/test/SourceLinesSocket/App.config
+++ b/csharp/test/SourceLinesSocket/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+</configuration>

--- a/csharp/test/SourceLinesSocket/Properties/AssemblyInfo.cs
+++ b/csharp/test/SourceLinesSocket/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SourceLinesSocket")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SourceLinesSocket")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("8bd9d160-77e3-4eb5-9cf6-69d41e5029c0")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/csharp/test/SourceLinesSocket/SourceLinesSocket.cs
+++ b/csharp/test/SourceLinesSocket/SourceLinesSocket.cs
@@ -1,0 +1,180 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SourceLinesSocket
+{
+    class SourceLinesSocket
+    {
+        private static Socket serverSocket;
+        private static IPAddress hostAddress;
+
+        private static volatile bool IsNeedStop = false;
+
+        const string TimeFormat = "yyyy-MM-dd HH:mm:ss";
+        const string MilliTimeFormat = TimeFormat + ".fff";
+        const string MicroTimeFormat = MilliTimeFormat + "fff";
+
+        static void Log(string message)
+        {
+            Console.WriteLine("{0} SourceLinesSocket : {1}", DateTime.Now.ToString(MilliTimeFormat), message);
+        }
+
+        static void Main(string[] args)
+        {
+            var exe = System.Reflection.Assembly.GetExecutingAssembly().CodeBase;
+            var exeName = Path.GetFileName(exe);
+
+            if (args.Length < 1 || args[0] == "-h" || args[0] == "--help")
+            {
+                Console.WriteLine("Usage :    {0}  port  [send-interval-milliseconds]   [running-seconds]  [bind-host]", exeName);
+                Console.WriteLine("Example-1: {0}  9111  100                            3600               127.0.0.1", exeName);
+                Console.WriteLine("Example-2: {0}  9111  100  3600 {1}", exeName, GetHost(false));
+                return;
+            }
+
+            int idxArg = -1;
+            Func<string, string, bool, string> getArg = (name, defaultArgValue, canBeNotSet) =>
+            {
+                idxArg++;
+                if (args.Length > idxArg)
+                {
+                    Log(string.Format("args[{0}] : {1} = {2}", idxArg, name, args[idxArg]));
+                    return args[idxArg];
+                }
+                else if (canBeNotSet)
+                {
+                    Log(string.Format("args--{0} : {1} = {2}", idxArg, name, defaultArgValue));
+                    return defaultArgValue;
+                }
+                else
+                {
+                    throw new ArgumentException(string.Format("cannot omit {0} at arg[{0}]", name, idxArg + 1), name);
+                }
+            };
+
+            var port = int.Parse(getArg("port", "", false));
+            var milliInterval = int.Parse(getArg("milliseconds-send-interval", "1000", true));
+            var runningSeconds = int.Parse(getArg("running-seconds", "3600", true));
+            var hostToUse = getArg("host-to-force-use", "", true);
+            var duration = runningSeconds <= 0 ? TimeSpan.MaxValue : new TimeSpan(0, 0, 0, runningSeconds);
+
+            hostAddress = !string.IsNullOrWhiteSpace(hostToUse) ? IPAddress.Parse(hostToUse) : GetHost();
+            serverSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            serverSocket.Bind(new IPEndPoint(hostAddress, port));
+            serverSocket.Listen(10);
+
+            var startTime = DateTime.Now;
+            var thread = new Thread(() => { ListenToClient(startTime, milliInterval, duration); });
+            thread.IsBackground = runningSeconds > 0;
+            thread.Start();
+
+            if (runningSeconds < 1)
+            {
+                return;
+            }
+
+            var process = Process.GetCurrentProcess();
+            var stopTime = startTime + duration;
+
+            Log("will stop at " + stopTime.ToString(MilliTimeFormat));
+            Thread.Sleep(runningSeconds * 1000);
+            Log("passed " + (DateTime.Now - startTime).TotalSeconds + " s, thread id = " + thread.ManagedThreadId + " , state = " + thread.ThreadState + ", isAlive = " + thread.IsAlive);
+            while (DateTime.Now < stopTime)
+            {
+                var remainSleep = (stopTime - DateTime.Now).TotalSeconds;
+                Log("passed " + (DateTime.Now - startTime).TotalSeconds + " s, still need wait " + remainSleep + " s. Thread id = " + thread.ManagedThreadId + " , state = " + thread.ThreadState + ", isAlive = " + thread.IsAlive);
+                Thread.Sleep((int)(remainSleep * 1000));
+            }
+
+            IsNeedStop = true;
+            Thread.Sleep(Math.Max(100, milliInterval));
+            Log("passed " + (DateTime.Now - startTime).TotalSeconds + " s, thread id = " + thread.ManagedThreadId + " , state = " + thread.ThreadState + ", isAlive = " + thread.IsAlive);
+            if (thread.IsAlive)
+            {
+                Log("try to kill process " + process.Id + " to stop thread id = " + thread.ManagedThreadId + " , state = " + thread.ThreadState);
+                process.Kill();
+                Log("try to exit to stop thread " + thread + " , state = " + thread.ThreadState);
+                Environment.Exit(0);
+            }
+
+            serverSocket.Dispose();
+        }
+
+        private static IPAddress GetHost(bool print = false)
+        {
+            IPAddress[] ips = Dns.GetHostAddresses(Dns.GetHostName());
+            foreach (IPAddress ipa in ips)
+            {
+                if (ipa.AddressFamily != AddressFamily.InterNetwork)
+                {
+                    continue;
+                }
+
+                if (print)
+                {
+                    Console.WriteLine("ip = {0}, AddressFamily = {1}", ipa, ipa.AddressFamily);
+                }
+
+                var ip = ipa.ToString();
+                if (ip.StartsWith("10.0.2.") && !ip.StartsWith("192.168."))
+                {
+                    return ipa;
+                }
+            }
+            
+            return IPAddress.Parse("127.0.0.1");
+        }
+        
+        private static void ListenToClient(DateTime startTime, int milliInterval, TimeSpan runningDuration, int times = 1)
+        {
+            var stopTime = runningDuration == TimeSpan.MaxValue ? "endless" : (startTime + runningDuration).ToString(MilliTimeFormat);
+            if (DateTime.Now - startTime > runningDuration)
+            {
+                Log("Not running. start from " + startTime.ToString(MilliTimeFormat) + " , running for " + runningDuration);
+                return;
+            }
+            else
+            {
+                Log("Machine = " + Environment.MachineName + ", OS = " + Environment.OSVersion
+                    + ", start listening " + serverSocket.LocalEndPoint.ToString()
+                    + (runningDuration == TimeSpan.MaxValue ? "  running endless " : "  will stop at " + stopTime));
+            }
+
+            var count = 0;
+            try
+            {
+                Socket clientSocket = serverSocket.Accept();
+                while (!IsNeedStop)
+                {
+                    if (DateTime.Now - startTime > runningDuration)
+                    {
+                        Log("Stop running. start from " + startTime.ToString(MilliTimeFormat) + " , running for " + runningDuration);
+                        break;
+                    }
+                    count++;
+                    var message = string.Format("{0} from '{1}' '{2}' {3} times[{4}] send message[{5}] to {6} : tick = {7}{8}",
+                        DateTime.Now.ToString(MicroTimeFormat), Environment.OSVersion, Environment.MachineName, hostAddress, times, count, clientSocket.RemoteEndPoint, DateTime.Now.Ticks, Environment.NewLine);
+                    Console.Write(message);
+                    clientSocket.Send(Encoding.ASCII.GetBytes(message));
+                    Thread.Sleep(milliInterval);
+                }
+
+                clientSocket.Close();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+                var thread = new Thread(() => { ListenToClient(startTime, milliInterval, runningDuration, times + 1); });
+                thread.Start();
+            }
+        }
+    }
+}

--- a/csharp/test/SourceLinesSocket/SourceLinesSocket.csproj
+++ b/csharp/test/SourceLinesSocket/SourceLinesSocket.csproj
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8BD9D160-77E3-4EB5-9CF6-69D41E5029C0}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SourceLinesSocket</RootNamespace>
+    <AssemblyName>SourceLinesSocket</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="SourceLinesSocket.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/csharp/test/SourceLinesSocket/SourceLinesSocket.sln
+++ b/csharp/test/SourceLinesSocket/SourceLinesSocket.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SourceLinesSocket", "SourceLinesSocket.csproj", "{8BD9D160-77E3-4EB5-9CF6-69D41E5029C0}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8BD9D160-77E3-4EB5-9CF6-69D41E5029C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8BD9D160-77E3-4EB5-9CF6-69D41E5029C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8BD9D160-77E3-4EB5-9CF6-69D41E5029C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8BD9D160-77E3-4EB5-9CF6-69D41E5029C0}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/csharp/test/testArgsQuotes/App.config
+++ b/csharp/test/testArgsQuotes/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+</configuration>

--- a/csharp/test/testArgsQuotes/Properties/AssemblyInfo.cs
+++ b/csharp/test/testArgsQuotes/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("testArgsQuotes")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("testArgsQuotes")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("cf692e77-8ea9-46ec-bf38-8f7a1bdafdd0")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/csharp/test/testArgsQuotes/testArgsQuotes.cs
+++ b/csharp/test/testArgsQuotes/testArgsQuotes.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Spark.CSharp.Core;
+using Microsoft.Spark.CSharp.Services;
+
+namespace testArgsQuotes
+{
+    class testArgsQuotes
+    {
+        const string TimeFormat = "yyyy-MM-dd HH:mm:ss";
+        const string MilliTimeFormat = TimeFormat + ".fff";
+        const string MicroTimeFormat = MilliTimeFormat + "fff";
+
+        static void Log(string message)
+        {
+            Console.WriteLine("{0} {1} : {2}", DateTime.Now.ToString(MilliTimeFormat), typeof(testArgsQuotes).Name, message);
+        }
+
+        static void Main(string[] args)
+        {
+            var exe = Path.GetFileName(System.Reflection.Assembly.GetExecutingAssembly().CodeBase);
+            if (args.Length < 1 || args[0] == "-h" || args[0] == "--help")
+            {
+                Console.WriteLine("Usage    : {0}  input-arguments", exe);
+                Console.WriteLine("Example-1: {0}  any-thing that you-want-to-write=input", exe);
+                var mapCurrentDir = new Dictionary<PlatformID, string> {
+                    {PlatformID.Win32NT, "%CD%" }, {PlatformID.Win32S, "%CD%" }, {PlatformID.Win32Windows, "%CD%" }, {PlatformID.WinCE, "%CD%" },
+                    {PlatformID.Unix, "$PWD" }
+                };
+
+                var currentDirectory = string.Empty;
+                if (mapCurrentDir.TryGetValue(Environment.OSVersion.Platform, out currentDirectory))
+                {
+                    Console.WriteLine(@"Example-2: {0}  {1}  arg2@*#:,+.-\/~", exe, currentDirectory);
+                }
+
+                return;
+            }
+
+            var idx = 0;
+            Log("args.Length = " + args.Length + Environment.NewLine
+                + string.Join(Environment.NewLine, args.Select(arg => { idx++; return "args[" + idx + "] = " + arg; }))
+                );
+
+            var singleValueRDD = new List<KeyValuePair<string, int>>(
+                args.Select(arg => new KeyValuePair<string, int>(arg, 1))
+             );
+
+            idx = 0;
+            singleValueRDD.ForEach(kv => Log(string.Format("src-pair[{0}] : {1} = {2}", idx++, kv.Key, kv.Value)));
+
+            var sparkContext = new SparkContext(new SparkConf().SetAppName(typeof(testArgsQuotes).Name));
+            var rdd = sparkContext.Parallelize(singleValueRDD);
+            Log(string.Format("Main() rdd = {0}", rdd));
+            var reduced = rdd.ReduceByKey((v1, v2) => v1 + v2);
+            Log("reduced.count = " + reduced.Count());
+            sparkContext.Stop();
+        }
+    }
+}

--- a/csharp/test/testArgsQuotes/testArgsQuotes.csproj
+++ b/csharp/test/testArgsQuotes/testArgsQuotes.csproj
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CF692E77-8EA9-46EC-BF38-8F7A1BDAFDD0}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>testArgsQuotes</RootNamespace>
+    <AssemblyName>testArgsQuotes</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="testArgsQuotes.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Adapter\Microsoft.Spark.CSharp\Adapter.csproj">
+      <Project>{ce999a96-f42b-4e80-b208-709d7f49a77c}</Project>
+      <Name>Adapter</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">copy /y $(ProjectDir)..\..\Worker\Microsoft.Spark.CSharp\bin\$(ConfigurationName)\CSharpWorker.* $(TargetDir)</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(OS)' == 'Unix' ">cp -uv $(ProjectDir)../../Worker/Microsoft.Spark.CSharp/bin/$(ConfigurationName)/CSharpWorker.* $(TargetDir)</PostBuildEvent>
+  </PropertyGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/csharp/test/testKeyValueStream/App.config
+++ b/csharp/test/testKeyValueStream/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+</configuration>

--- a/csharp/test/testKeyValueStream/ParseKeyValuePair.cs
+++ b/csharp/test/testKeyValueStream/ParseKeyValuePair.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace testKeyValueStream
+{
+    [Serializable]
+    abstract class ParseKeyValuePairBase<ValueType>
+    {
+        protected readonly long valueArrayElements;
+
+        protected readonly bool needPrintMessage;
+
+        public ParseKeyValuePairBase(long valueElementCount = 0, bool needPrintMessage = true)
+        {
+            this.valueArrayElements = valueElementCount;
+            this.needPrintMessage = needPrintMessage;
+        }
+
+        public virtual void Log(string message)
+        {
+            Console.WriteLine("{0} {1} : {2}", TestUtils.NowMilli, this.GetType().Name, message);
+        }
+
+        public virtual KeyValuePair<string, ValueType> Parse(string line)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected static KeyValuePair<string, int[]> Parse(string line, long elements)
+        {
+            // Log("received line : " + line);
+            var match = Regex.Match(line, @"^.*tick\s*=\s*(?<Key>\d{9})(?<Value>\d+)");
+            var key = match.Groups["Key"].Value;
+            var valueSet = Regex.Matches(match.Groups["Value"].Value, "\\d");
+            var values = new int[elements];
+            var n = Math.Min(valueSet.Count, values.Length);
+            for (var k = 0; k < n; k++)
+            {
+                values[k] = int.Parse(valueSet[k].Value);
+            }
+
+            return new KeyValuePair<string, int[]>(key, values);
+        }
+
+        protected void Print(KeyValuePair<string, int[]> kv)
+        {
+            if (needPrintMessage)
+            {
+                Log(string.Format("key = {0} , value{1}", kv.Key, TestUtils.ArrayToText(kv.Value)));
+            }
+        }
+    }
+
+    [Serializable]
+    class ParseKeyValueArray : ParseKeyValuePairBase<int[]>
+    {
+        public ParseKeyValueArray(long valueElementCount = 0, bool needPrintMessage = true) : base(valueElementCount, needPrintMessage) { }
+        public override KeyValuePair<string, int[]> Parse(string line)
+        {
+            var kv = Parse(line, this.valueArrayElements);
+            Print(kv);
+            return kv;
+        }
+    }
+
+    [Serializable]
+    class ParseKeyValueUnevenArray : ParseKeyValueArray
+    {
+        private static Random random = new Random(DateTime.Now.Second);
+
+        public ParseKeyValueUnevenArray(long valueElementCount = 0, bool needPrintMessage = true) : base(valueElementCount, needPrintMessage) { }
+
+        public override KeyValuePair<string, int[]> Parse(string line)
+        {
+            var kv = Parse(line);
+            var values = kv.Value.ToList();
+            int removeCount = random.Next() % (values.Count + 1);
+            values.RemoveRange(0, removeCount);
+            var pair = new KeyValuePair<string, int[]>(kv.Key, values.ToArray());
+            Print(pair);
+            return pair;
+        }
+    }
+
+    [Serializable]
+    class ParseKeyValue : ParseKeyValuePairBase<int>
+    {
+        public ParseKeyValue(long valueArrayElements = 0, bool needPrintMessage = true) : base(valueArrayElements, needPrintMessage) { }
+
+        public override KeyValuePair<string, int> Parse(string line)
+        {
+            var kv = Parse(line, 1);
+            Print(kv);
+            return new KeyValuePair<string, int>(kv.Key, kv.Value[0]);
+        }
+    }
+}

--- a/csharp/test/testKeyValueStream/Properties/AssemblyInfo.cs
+++ b/csharp/test/testKeyValueStream/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("testKeyValueStream")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("testKeyValueStream")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e40f7467-a33e-4ccd-841a-ebb14ffb75ef")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/csharp/test/testKeyValueStream/TestUtils.cs
+++ b/csharp/test/testKeyValueStream/TestUtils.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace testKeyValueStream
+{
+    public class TestUtils
+    {
+        public const string TimeFormat = "yyyy-MM-dd HH:mm:ss";
+        public const string MilliTimeFormat = TimeFormat + ".fff";
+        public const string MicroTimeFormat = MilliTimeFormat + "fff";
+
+        public static string Now { get { return DateTime.Now.ToString(TimeFormat); } }
+
+        public static string NowMilli { get { return DateTime.Now.ToString(MilliTimeFormat); } }
+
+        public static string NowMicro { get { return DateTime.Now.ToString(MicroTimeFormat); } }
+
+        public static string ArrayToText<T>(T[] array, int takeMaxElementCount = 9)
+        {
+            if (array == null)
+            {
+                return "[] = null";
+            }
+            else if (array.Length == 0)
+            {
+                return "[0] = " + array;
+            }
+            else if (array.Length <= takeMaxElementCount)
+            {
+                return "[" + array.Length + "] = " + string.Join(", ", array);
+            }
+            else
+            {
+                return "[" + array.Length + "] = " + string.Join(", ", array.Take(takeMaxElementCount)) + ", ... , " + array.Last();
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="ArgType"></typeparam>
+        /// <param name="index">start from -1</param>
+        /// <param name="args"></param>
+        /// <param name="argName"></param>
+        /// <param name="defaultValue"></param>
+        /// <param name="canOutOfArgs">not in args</param>
+        /// <returns></returns>
+        public static ArgType GetArgValue<ArgType>(ref int index, string[] args, string argName, ArgType defaultValue, bool canOutOfArgs = true)
+        {
+            index++;
+            if (args.Length > index)
+            {
+                Console.WriteLine("args[{0}] : {1} = {2}", index, argName, args[index]);
+                var argValue = args[index];
+                if (defaultValue is bool)
+                {
+                    argValue = Regex.IsMatch(args[index], "1|true", RegexOptions.IgnoreCase).ToString();
+                }
+
+                return (ArgType)TypeDescriptor.GetConverter(typeof(ArgType)).ConvertFromString(argValue);
+            }
+            else if (canOutOfArgs)
+            {
+                Console.WriteLine("args[{0}] : {1} = {2}", index, argName, defaultValue);
+                return defaultValue;
+            }
+            else
+            {
+                throw new ArgumentException(string.Format("must set {0} at arg[{0}]", argName, index + 1), argName);
+            }
+        }
+    }
+}

--- a/csharp/test/testKeyValueStream/packages.config
+++ b/csharp/test/testKeyValueStream/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="log4net" version="2.0.5" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="Razorvine.Pyrolite" version="4.10.0.0" targetFramework="net452" />
+  <package id="Razorvine.Serpent" version="1.12.0.0" targetFramework="net452" />
+</packages>

--- a/csharp/test/testKeyValueStream/test-array-kv-stream.bat
+++ b/csharp/test/testKeyValueStream/test-array-kv-stream.bat
@@ -1,0 +1,55 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set shellDir=%~dp0
+set exeDir=%shellDir%bin\Debug
+
+if "%1" == "" (
+    %exeDir%\testKeyValueStream.exe
+    exit /b 0
+)
+
+pushd %CD%
+
+pushd %~dp0..\..\..
+set codeRoot=%CD%
+
+set HADOOP_HOME=%codeRoot%\build\tools\winutils
+set SPARK_HOME=%codeRoot%\build\tools\spark-1.6.1-bin-hadoop2.6
+set SPARKCLR_HOME=%codeRoot%\build\runtime
+
+pushd %~dp0\bin\Debug 
+
+set options=--executor-cores 2 --driver-cores 2 --executor-memory 1g --driver-memory 1g
+
+echo %SPARKCLR_HOME%\scripts\sparkclr-submit.cmd --verbose %options% --exe testKeyValueStream.exe %CD% %*
+%SPARKCLR_HOME%\scripts\sparkclr-submit.cmd --verbose %options% --exe testKeyValueStream.exe %CD% %*
+
+popd
+
+popd
+
+@exit /b 0
+
+::=== following are test commands example ==========================================
+
+:: Enable/Disable echo in *.cmd files for debug : use -R to replace ; Without -R to preview
+lzmw -f "\.cmd$" -d "tools|scripts|localmode" -it "^(\s*@?\s*echo\s+)off" -o "$1 on" -rp d:\msgit\lqmMobius  -R
+lzmw -f "\.cmd$" -d "tools|scripts|localmode" -it "^(\s*@?\s*echo\s+)on" -o "$1 off" -rp d:\msgit\lqmMobius  -R
+
+:: Start source stream socket and test
+d:\msgit\lqmMobius\csharp\test\SourceLinesSocket\bin\Debug\SourceLinesSocket.exe 9111 100 0
+d:\msgit\lqmMobius\csharp\test\testKeyValueStream\test-array-kv-stream.bat 127.0.0.1 9111 1 30 20 checkDir 0 1 0 10485760  2>d:\tmp\logKvError.log > d:\tmp\logKvOut.log
+
+:: Find log in directory with above logs in directory d:\tmp
+lzmw -p d:\tmp -f "^logKv.*\.log$" -it "cannot|fail|error|exception" --nt "sleep interrupted|goto|echo\s+" -U 9 -D 9 -c
+lzmw -p d:\tmp -f logKv -it "thread st\w+|released [1-9]\d*|alive objects|used \d+|(begin|end) of|dispose"
+
+:: Find latest log ignore file name under Cygwin on Windows in directory /cygdrive/d/tmp/ 
+lzmw -c --w1 "$(lzmw -l --wt -T 2 -PIC 2>/dev/null | head -n 1 | awk -F '\t' '{print $1}' )" -it "cannot|fail|error|exception" --nt "sleep interrupted|goto|echo\s+" -U 9 -D 9
+lzmw -c --w1 "$(lzmw -l --wt -T 2 -PIC 2>/dev/null | head -n 1 | awk -F '\t' '{print $1}' )" -it "thread st\w+|dispose|released [1-9]\d*|finished all" -e "\d+ alive"
+lzmw -c --w1 "$(lzmw -l --wt -T 2 -PIC 2>/dev/null | head -n 1 | awk -F '\t' '{print $1}' )" -it "JVMObjectTracker" -H 3 -T 3
+lzmw -c --w1 "$(lzmw -l --wt -T 2 -PIC 2>/dev/null | head -n 1 | awk -F '\t' '{print $1}' )" -it "thread st\w+|released [1-9]\d*|alive objects|used \d+|(begin|end) of|dispose"
+
+:: Kill test process under Cygwin on Windows
+for pid in $(wmic process get processid, name | lzmw -it '^.*testKeyValueStream.exe\s+(\d+).*$' -o '$1' -PAC); do taskkill /f /pid $pid ; done

--- a/csharp/test/testKeyValueStream/test-array-kv-stream.sh
+++ b/csharp/test/testKeyValueStream/test-array-kv-stream.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+cd $(dirname $0)
+shellDir=$PWD
+
+cd $(dirname $0)/../../..
+codeRoot=$PWD
+
+echo "shellDir = $shellDir , codeRoot = $codeRoot"
+#export HADOOP_HOME=$codeRoot/build/tools/winutils
+#export SPARK_HOME=$codeRoot/build/tools/spark-1.6.1-bin-hadoop2.6
+export SPARKCLR_HOME=$codeRoot/build/runtime
+
+cd $shellDir/bin/Debug # && rm -rf checkDir
+LZEXE=./testKeyValueStream.exe
+CSMONO=mono #$(locate mono)
+if [ $# -lt 1 ]; then
+	$CSMONO $LZEXE
+	exit
+fi
+
+## local mode
+# $SPARKCLR_HOME/scripts/sparkclr-submit.sh --verbose --exe $LZEXE $PWD $@
+
+## cluster mode
+options="--executor-cores 2 --driver-cores 2 --executor-memory 1g --driver-memory 1g"
+$SPARKCLR_HOME/scripts/sparkclr-submit.sh --verbose $options --master yarn-cluster --exe $LZEXE $PWD $@ 
+

--- a/csharp/test/testKeyValueStream/testKeyValueStream.cs
+++ b/csharp/test/testKeyValueStream/testKeyValueStream.cs
@@ -1,0 +1,260 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Spark.CSharp.Core;
+using Microsoft.Spark.CSharp.Streaming;
+using Microsoft.Spark.CSharp.Interop;
+using Microsoft.Spark.CSharp.Services;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+
+namespace testKeyValueStream
+{
+    public class testKeyValueStream
+    {
+        static string host = "127.0.0.1";
+        static int port = 9111;
+        static int windowSeconds = 1;
+        static int runningSeconds = 30;
+        static int totalTestTimes = 20;
+        static string checkpointDirectory = "checkDir";
+        static bool isReduceByKeyAndWindow = false;
+        static bool isValueArray = true;
+        static bool isUnevenArray = false;
+        static long valueElements = 1024 * 1024 * 20;
+        static bool needSaveToTxtFile = false;
+        static bool checkArrayBeforeReduce = true;
+
+        public static void Main(string[] args)
+        {
+            var exeName = Path.GetFileName(System.Reflection.Assembly.GetExecutingAssembly().CodeBase);
+
+            // TestReceivedLine();
+            if (args.Length < 1 || args[0] == "-h" || args[0] == "--help")
+            {
+                Console.WriteLine("Usage :    {0}  Host       Port [windowSeconds] [runningSeconds] [testTimes] [checkpointDirectory] [isReduceByKeyAndWindow] [isValueArray] [isUnevenArray] [valueArrayElements] [saveTxt] [checkArrayBeforeReduce]", exeName);
+                Console.WriteLine("Example-1: {0}  127.0.0.1  9111   1               30               20         checkDir               0                        1          0                  1048576              0         1", exeName);
+                Console.WriteLine("Example-2: {0}  {1} 9111 1 30 20 checkDir 0 1 0 1048576 0 1", exeName, GetHost());
+                Console.WriteLine("The above host and port are from a tool : SourceLinesSocket in this project.");
+                return;
+            }
+
+            int idxArg = -1;
+
+            host = TestUtils.GetArgValue(ref idxArg, args, "host", host, false);
+            port = TestUtils.GetArgValue(ref idxArg, args, "port", port, false);
+            windowSeconds = TestUtils.GetArgValue(ref idxArg, args, "windowSeconds", windowSeconds);
+            runningSeconds = TestUtils.GetArgValue(ref idxArg, args, "runningSeconds", runningSeconds);
+            totalTestTimes = TestUtils.GetArgValue(ref idxArg, args, "totalTestTimes", totalTestTimes);
+            checkpointDirectory = TestUtils.GetArgValue(ref idxArg, args, "checkpointDirectory", checkpointDirectory);
+            isReduceByKeyAndWindow = TestUtils.GetArgValue(ref idxArg, args, "isReduceByKeyAndWindow", isReduceByKeyAndWindow);
+            isValueArray = TestUtils.GetArgValue(ref idxArg, args, "isValueArray", isValueArray);
+            isUnevenArray = TestUtils.GetArgValue(ref idxArg, args, "isUnevenArray", isUnevenArray);
+            valueElements = TestUtils.GetArgValue(ref idxArg, args, "valueArrayElements", valueElements);
+            needSaveToTxtFile = TestUtils.GetArgValue(ref idxArg, args, "needSaveToTxtFile", needSaveToTxtFile);
+            checkArrayBeforeReduce = TestUtils.GetArgValue(ref idxArg, args, "checkArrayBeforeReduce", checkArrayBeforeReduce);
+
+            Log("will connect " + host + ":" + port + " , windowSeconds = " + windowSeconds + " s. " + checkpointDirectory + " = " + checkpointDirectory + ", is-array-test = " + isValueArray);
+
+            var prefix = exeName + (isValueArray ? "-array" + (isUnevenArray ? "-uneven" : "-even") : "-single") + "-";
+            var sc = new SparkContext(new SparkConf().SetAppName(prefix));
+
+            var beginTime = DateTime.Now;
+
+            Action<long> testOneStreaming = (testTime) =>
+            {
+                var timesInfo = " test[" + testTime + "]-" + totalTestTimes + " ";
+                Log("============== begin of " + timesInfo + " =========================");
+                var durationSeconds = windowSeconds;
+                var ssc = new StreamingContext(sc, durationSeconds);
+                ssc.Checkpoint(checkpointDirectory);
+                var lines = ssc.SocketTextStream(host, port, StorageLevelType.MEMORY_AND_DISK_SER);
+
+                StartOneTest(sc, lines, prefix);
+
+                ssc.Start();
+                var startTime = DateTime.Now;
+                ssc.AwaitTerminationOrTimeout(runningSeconds * 1000);
+                Log(string.Format("============= end of {0}, start from {1} , used {2} s. total cost {3} s.======================",
+                    timesInfo, startTime.ToString(TestUtils.MilliTimeFormat), (DateTime.Now - startTime).TotalSeconds, (DateTime.Now - beginTime).TotalSeconds));
+                ssc.Stop();
+            };
+
+
+            for (var times = 0; times < totalTestTimes; times++)
+            {
+                testOneStreaming(times + 1);
+            }
+
+            Log("finished all test , total test times = " + totalTestTimes + ", used time = " + (DateTime.Now - beginTime));
+        }
+
+        static void Log(string message)
+        {
+            Console.WriteLine("{0} {1} : {2}", TestUtils.NowMilli, typeof(testKeyValueStream).Name, message);
+        }
+
+        static void StartOneTest(SparkContext sc, DStream<string> lines, string prefix, string suffix = ".txt")
+        {
+            if (!isValueArray)
+            {
+                var pairs = lines.Map(line => new ParseKeyValue(0).Parse(line));
+                var reducedStream = isReduceByKeyAndWindow ? pairs.ReduceByKeyAndWindow(SumReduce, InverseSum, windowSeconds)
+                    : pairs.ReduceByKey(SumReduce);
+                ForEachRDD("KeyValue", reducedStream, prefix, suffix);
+            }
+            else if (isUnevenArray)
+            {
+                var pairs = lines.Map(line => new ParseKeyValueUnevenArray(valueElements).Parse(line));
+                var reducedStream = isReduceByKeyAndWindow ? pairs.ReduceByKeyAndWindow(SumReduce, InverseSum, windowSeconds)
+                    : pairs.ReduceByKey(SumReduce);
+                ForEachRDD("KeyValueUnevenArray", reducedStream, prefix, suffix);
+
+            }
+            else
+            {
+                var pairs = lines.Map(line => new ParseKeyValueArray(valueElements).Parse(line));
+                var reducedStream = isReduceByKeyAndWindow ? pairs.ReduceByKeyAndWindow(SumReduce, InverseSum, windowSeconds)
+                    : pairs.ReduceByKey(SumReduce);
+                ForEachRDD("KeyValueEvenArray", reducedStream, prefix, suffix);
+            }
+        }
+
+        static void ForEachRDD<V>(string title, DStream<KeyValuePair<string, V>> reducedStream, string prefix, string suffix = ".txt")
+        {
+            Log("ForEachRDD " + title);
+            reducedStream.ForeachRDD((time, rdd) =>
+            {
+                var taken = rdd.Collect();
+                Console.WriteLine("{0} taken.length = {1} , taken = {2}", TestUtils.NowMilli, taken.Length, taken);
+
+                foreach (object record in taken)
+                {
+                    KeyValuePair<string, V> countByWord = (KeyValuePair<string, V>)record;
+                    Console.WriteLine("{0} record = {1}, countByWord : key = {2}, value = {3}", TestUtils.NowMilli, record, countByWord.Key, GetValueText(countByWord.Value));
+                }
+            });
+
+            Log(string.Format("{0} reducedStream.Count = {1}", title, reducedStream.Count()));
+
+            if (needSaveToTxtFile)
+            {
+                reducedStream.SaveAsTextFiles(prefix, suffix);
+            }
+        }
+
+        static int[] SumReduce(int[] a, int[] b)
+        {
+            Log(string.Format("SumReduce() a{0}, b{1}", TestUtils.ArrayToText(a), TestUtils.ArrayToText(b)));
+
+            if (checkArrayBeforeReduce)
+            {
+                if (a == null || b == null)
+                {
+                    return a == null ? b : a;
+                }
+
+                if (a.Length == 0 || b.Length == 0)
+                {
+                    return a.Length == 0 ? b : a;
+                }
+            }
+
+            var count = checkArrayBeforeReduce ? Math.Min(a.Length, b.Length) : a.Length;
+            var c = new int[count];
+            for (var k = 0; k < c.Length; k++)
+            {
+                c[k] = a[k] + b[k];
+            }
+
+            return c;
+        }
+
+        static int SumReduce(int a, int b)
+        {
+            return a + b;
+        }
+
+        static int[] InverseSum(int[] a, int[] b)
+        {
+            Log(string.Format("InverseSum() a{0}, b{1}", TestUtils.ArrayToText(a), TestUtils.ArrayToText(b)));
+            if (checkArrayBeforeReduce)
+            {
+                if (a == null || b == null)
+                {
+                    return a == null ? b : a;
+                }
+
+                if (a.Length == 0 || b.Length == 0)
+                {
+                    return a.Length == 0 ? b : a;
+                }
+            }
+
+            var count = checkArrayBeforeReduce ? Math.Min(a.Length, b.Length) : a.Length;
+            var c = new int[count];
+            for (var k = 0; k < c.Length; k++)
+            {
+                c[k] = a[k] - b[k];
+            }
+            return c;
+        }
+
+        static int InverseSum(int a, int b)
+        {
+            return a - b;
+        }
+
+        static string GetValueText(object value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            if (value is int)
+            {
+                return ((int)value).ToString();
+            }
+            else if (value is int[])
+            {
+                return TestUtils.ArrayToText((int[])value);
+            }
+            else
+            {
+                return value.ToString();
+            }
+        }
+
+        static IPAddress GetHost(bool print = false)
+        {
+            IPAddress[] ips = Dns.GetHostAddresses(Dns.GetHostName());
+            var ipList = new List<IPAddress>();
+            foreach (IPAddress ipa in ips)
+            {
+                if (ipa.AddressFamily != AddressFamily.InterNetwork)
+                {
+                    continue;
+                }
+
+                if (print)
+                {
+                    Console.WriteLine("ip = {0}, AddressFamily = {1}", ipa, ipa.AddressFamily);
+                }
+
+                var ip = ipa.ToString();
+                if (!ip.StartsWith("10.0.2.") && !ip.StartsWith("192.168."))
+                {
+                    return ipa;
+                }
+            }
+
+            return IPAddress.Parse("127.0.0.1");
+        }
+    }
+}

--- a/csharp/test/testKeyValueStream/testKeyValueStream.csproj
+++ b/csharp/test/testKeyValueStream/testKeyValueStream.csproj
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E40F7467-A33E-4CCD-841A-EBB14FFB75EF}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>testKeyValueStream</RootNamespace>
+    <AssemblyName>testKeyValueStream</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Razorvine.Pyrolite, Version=4.10.0.26455, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Razorvine.Pyrolite.4.10.0.0\lib\net40\Razorvine.Pyrolite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Razorvine.Serpent, Version=1.12.0.35091, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Razorvine.Serpent.1.12.0.0\lib\net40\Razorvine.Serpent.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ParseKeyValuePair.cs" />
+    <Compile Include="testKeyValueStream.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestUtils.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+    <None Include="test-array-kv-stream.bat" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Adapter\Microsoft.Spark.CSharp\Adapter.csproj">
+      <Project>{ce999a96-f42b-4e80-b208-709d7f49a77c}</Project>
+      <Name>Adapter</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">copy /y $(ProjectDir)..\..\Worker\Microsoft.Spark.CSharp\bin\$(ConfigurationName)\CSharpWorker.* $(TargetDir)</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(OS)' == 'Unix' ">cp -uv $(ProjectDir)../../Worker/Microsoft.Spark.CSharp/bin/$(ConfigurationName)/CSharpWorker.* $(TargetDir)</PostBuildEvent>
+  </PropertyGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/csharp/test/testKeyValueStream/testKeyValueStream.sln
+++ b/csharp/test/testKeyValueStream/testKeyValueStream.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "testKeyValueStream", "testKeyValueStream.csproj", "{E40F7467-A33E-4CCD-841A-EBB14FFB75EF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SourceLinesSocket", "..\SourceLinesSocket\SourceLinesSocket.csproj", "{8BD9D160-77E3-4EB5-9CF6-69D41E5029C0}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E40F7467-A33E-4CCD-841A-EBB14FFB75EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E40F7467-A33E-4CCD-841A-EBB14FFB75EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E40F7467-A33E-4CCD-841A-EBB14FFB75EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E40F7467-A33E-4CCD-841A-EBB14FFB75EF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8BD9D160-77E3-4EB5-9CF6-69D41E5029C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8BD9D160-77E3-4EB5-9CF6-69D41E5029C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8BD9D160-77E3-4EB5-9CF6-69D41E5029C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8BD9D160-77E3-4EB5-9CF6-69D41E5029C0}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Release JVMObjectTracker oject reference.
1.Java-side: https://github.com/Microsoft/Mobius/blob/master/scala/src/main/org/apache/spark/api/csharp/CSharpBackendHandler.scala#L269
JVMObjectTracker keep a HashMap[String, Object] which is [id, Java-object]

2.CSharp-side :
    1) JvmObjectReference remember the id : https://github.com/Microsoft/Mobius/blob/master/csharp/Adapter/Microsoft.Spark.CSharp/Interop/Ipc/JvmObjectReference.cs#L20 
    2) So JvmBridge can call java object's method https://github.com/Microsoft/Mobius/blob/master/csharp/Adapter/Microsoft.Spark.CSharp/Interop/Ipc/JvmBridge.cs#L69
    So potential memory leak can happen in JVMObjectTracker.
    To solve this, track the garbage collection in CSharp side, get the id, release JVMObjectTracker's HashMap. 