### PR TITLE
Fix build scripts to comsume msbuild v12.0

### DIFF
--- a/csharp/Build.cmd
+++ b/csharp/Build.cmd
@@ -5,11 +5,13 @@ SET CMDHOME=%~dp0
 @REM Remove trailing backslash \
 set CMDHOME=%CMDHOME:~0,-1%
 
-@REM Set some .NET directory locations required if running from PowerShell prompt.
-if "%FrameworkDir%" == "" set FrameworkDir=%WINDIR%\Microsoft.NET\Framework
-if "%FrameworkVersion%" == "" set FrameworkVersion=v4.0.30319
+@REM Set msbuild location.
+SET VisualStudioVersion=12.0
 
-SET MSBUILDEXEDIR=%FrameworkDir%\%FrameworkVersion%
+SET MSBUILDEXEDIR=%programfiles(x86)%\MSBuild\%VisualStudioVersion%\Bin
+if NOT EXIST "%MSBUILDEXEDIR%\." SET MSBUILDEXEDIR=%programfiles%\MSBuild\%VisualStudioVersion%\Bin
+if NOT EXIST "%MSBUILDEXEDIR%\." GOTO :ErrorMSBUILD
+
 SET MSBUILDEXE=%MSBUILDEXEDIR%\MSBuild.exe
 SET MSBUILDOPT=/verbosity:minimal
 
@@ -62,6 +64,12 @@ if EXIST %PROJ_NAME%.nuspec (
 @echo ===== Build succeeded for %PROJ% =====
 
 @GOTO :EOF
+
+:ErrorMSBUILD
+set RC=1
+@echo ===== Build FAILED due to missing MSBUILD.EXE. =====
+@echo ===== Mobius requires "Developer Command Prompt for VS2013" and above =====
+exit /B %RC%
 
 :ErrorStop
 set RC=%ERRORLEVEL%

--- a/csharp/Clean.cmd
+++ b/csharp/Clean.cmd
@@ -1,3 +1,3 @@
-FOR /F "tokens=*" %%G IN ('DIR /B /AD /S bin') DO RMDIR /S /Q "%%G"
-FOR /F "tokens=*" %%G IN ('DIR /B /AD /S obj') DO RMDIR /S /Q "%%G"
-@REM FOR /F "tokens=*" %%G IN ('DIR /B /AD /S TestResults') DO RMDIR /S /Q "%%G"
+@ECHO OFF
+FOR /D /R . %%G IN (bin) DO @IF EXIST "%%G" (@echo RDMR /S /Q "%%G" & rd /s /q "%%G")
+FOR /D /R . %%G IN (obj) DO @IF EXIST "%%G" (@echo RDMR /S /Q "%%G" & rd /s /q "%%G")

--- a/examples/Build.cmd
+++ b/examples/Build.cmd
@@ -5,11 +5,12 @@ SET CMDHOME=%~dp0
 @REM Remove trailing backslash \
 set CMDHOME=%CMDHOME:~0,-1%
 
-@REM Set some .NET directory locations required if running from PowerShell prompt.
-if "%FrameworkDir%" == "" set FrameworkDir=%WINDIR%\Microsoft.NET\Framework
-if "%FrameworkVersion%" == "" set FrameworkVersion=v4.0.30319
+@REM Set msbuild location.
+SET VisualStudioVersion=12.0
 
-SET MSBUILDEXEDIR=%FrameworkDir%\%FrameworkVersion%
+SET MSBUILDEXEDIR=%programfiles(x86)%\MSBuild\%VisualStudioVersion%\Bin
+if NOT EXIST "%MSBUILDEXEDIR%\." SET MSBUILDEXEDIR=%programfiles%\MSBuild\%VisualStudioVersion%\Bin
+
 SET MSBUILDEXE=%MSBUILDEXEDIR%\MSBuild.exe
 SET MSBUILDOPT=/verbosity:minimal
 

--- a/examples/Clean.cmd
+++ b/examples/Clean.cmd
@@ -1,3 +1,3 @@
-FOR /F "tokens=*" %%G IN ('DIR /B /AD /S bin') DO RMDIR /S /Q "%%G"
-FOR /F "tokens=*" %%G IN ('DIR /B /AD /S obj') DO RMDIR /S /Q "%%G"
-@REM FOR /F "tokens=*" %%G IN ('DIR /B /AD /S TestResults') DO RMDIR /S /Q "%%G"
+@ECHO OFF
+FOR /D /R . %%G IN (bin) DO @IF EXIST "%%G" (@echo RDMR /S /Q "%%G" & rd /s /q "%%G")
+FOR /D /R . %%G IN (obj) DO @IF EXIST "%%G" (@echo RDMR /S /Q "%%G" & rd /s /q "%%G")


### PR DESCRIPTION
Currently, we are using the msbuild with v4.0 to compile .NET code. this change is to consume v12.0 one.