### PR TITLE
Disabled LogFileAppender for CSharpWorker

### DIFF
--- a/csharp/Worker/Microsoft.Spark.CSharp/App.config
+++ b/csharp/Worker/Microsoft.Spark.CSharp/App.config
@@ -11,7 +11,9 @@
     <root>
       <level value="INFO" />
       <appender-ref ref="ConsoleAppender" />
+      <!--
       <appender-ref ref="LogFileAppender" />
+      -->
     </root>
     <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
       <layout type="log4net.Layout.PatternLayout">


### PR DESCRIPTION
* Usually it's not necessary to enable two log appenders at the same time. For `LogFileAppender`, the output location is under `%TEMP%` directory (on drive `C:\` by default). We should let user to make the call whether to write logs to `%TEMP%` directory.
* Comment out `LogFileAppender` in CSharpWorker `app.config`, only `ConsoleAppender` is enabled by default