### PR TITLE
add kafka cluster id and refactor UpdateStateByKey API

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Core/PairRDDFunctions.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Core/PairRDDFunctions.cs
@@ -919,7 +919,7 @@ namespace Microsoft.Spark.CSharp.Core
         }
         
         [Serializable]
-        private class AddShuffleKeyHelper<K, V>
+        internal class AddShuffleKeyHelper<K, V>
         {
             [NonSerialized]
             private MD5 md5 = MD5.Create();


### PR DESCRIPTION
1. add "cluster.id" in kafkaParams when calling KafkaUtils.CreateDirectStreamWithRepartition to unique identify a topic.
2. refactor UpdateStateByKey API to complete pipelined RDD before transforming to CSharpStateDStream so that no extra CSharpRDDs in UpdateStateByKey and its parallel job covers all pipelined operations before shuffling.