### PR TITLE
Add RIOSocketWrapper and SaeaSocketWrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.user
 *.csproj.user
 *.iml
+*.VC.*
 
 # Compiled source #
 ###################
@@ -27,6 +28,10 @@
 **/packages/
 **/target/
 **/.idea/
+**/x64/
+**/debug/
+**/release/
+**/TestResults/
 scala/dependency-reduced-pom.xml
 build/runtime/
 build/tools/

--- a/build/Build.cmd
+++ b/build/Build.cmd
@@ -106,6 +106,29 @@ if EXIST "%CMDHOME%\lib" (
   )
 )
 
+:buildCpp
+Set CppSkipped=0
+@echo Assemble Mobius C++ components (RIOSOCK)
+pushd %CMDHOME%\..\cpp
+call Clean.cmd
+call Build.cmd
+
+if %ERRORLEVEL% EQU 2 (
+  set CppSkipped=1
+  popd
+  goto :buildCSharp
+)
+
+if %ERRORLEVEL% NEQ 0 (
+  @echo Build Mobius C++ RIOSOCK failed, stop building.
+  popd
+  goto :eof
+)
+@echo Mobius C++ RIOSOCK binaries
+copy /y x64\Release\*.dll "%SPARKCLR_HOME%\bin\"
+copy /y x64\Release\*.pdb "%SPARKCLR_HOME%\bin\"
+popd
+
 :buildCSharp
 @echo Assemble Mobius C# components
 pushd "%CMDHOME%\..\csharp"
@@ -215,3 +238,16 @@ copy /Y "%CMDHOME%\..\notes\mobius-release-info.md"
 
 :distdone
 popd
+
+if %CppSkipped% EQU 1 (
+    @echo. 
+    @echo ============================================================================================
+    @echo.
+    @echo   Note!!! Skipped to build Mobius C++ components due to missing VC++ Build Toolset.
+    @echo              If you want to compile C++ components, please enalble VC++ language from
+    @echo              Visual Studio. You can either download "Visual C++ Build Tools" availabe at 
+    @echo              "http://landinghub.visualstudio.com/visual-cpp-build-tools"
+    @echo. 
+    @echo ============================================================================================
+    @echo.
+)

--- a/cpp/Build.cmd
+++ b/cpp/Build.cmd
@@ -5,15 +5,16 @@ SET CMDHOME=%~dp0
 @REM Remove trailing backslash \
 set CMDHOME=%CMDHOME:~0,-1%
 
+set PROJ_NAME=Riosock
+set PROJ=%CMDHOME%\%PROJ_NAME%.sln
+
 @REM Set msbuild location.
 SET VisualStudioVersion=12.0
 if EXIST "%VS140COMNTOOLS%" SET VisualStudioVersion=14.0
 
-@REM Set Build OS
-SET CppDll=HasCpp
 SET VCBuildTool="%VS120COMNTOOLS:~0,-14%VC\bin\cl.exe"
 if EXIST "%VS140COMNTOOLS%" SET VCBuildTool="%VS140COMNTOOLS:~0,-14%VC\bin\cl.exe"
-if NOT EXIST %VCBuildTool% SET CppDll=NoCpp
+if NOT EXIST %VCBuildTool% GOTO :ErrorNoCLEXE
 
 SET MSBUILDEXEDIR=%programfiles(x86)%\MSBuild\%VisualStudioVersion%\Bin
 if NOT EXIST "%MSBUILDEXEDIR%\." SET MSBUILDEXEDIR=%programfiles%\MSBuild\%VisualStudioVersion%\Bin
@@ -27,17 +28,7 @@ if "%builduri%" == "" set builduri=Build.cmd
 cd "%CMDHOME%"
 @cd
 
-set PROJ_NAME=SparkCLR
-set PROJ=%CMDHOME%\%PROJ_NAME%.sln
-
 @echo ===== Building %PROJ% =====
-
-@echo Restore NuGet packages ===================
-SET STEP=NuGet-Restore
-
-nuget restore "%PROJ%"
-
-@if ERRORLEVEL 1 GOTO :ErrorStop
 
 @echo Build Debug ==============================
 SET STEP=Debug
@@ -46,7 +37,7 @@ SET CONFIGURATION=%STEP%
 
 SET STEP=%CONFIGURATION%
 
-"%MSBUILDEXE%" /p:Configuration=%CONFIGURATION%;AllowUnsafeBlocks=true %MSBUILDOPT% "%PROJ%"
+"%MSBUILDEXE%" /p:Configuration=%CONFIGURATION% %MSBUILDOPT% "%PROJ%"
 @if ERRORLEVEL 1 GOTO :ErrorStop
 @echo BUILD ok for %CONFIGURATION% %PROJ%
 
@@ -55,7 +46,7 @@ SET STEP=Release
 
 SET CONFIGURATION=%STEP%
 
-"%MSBUILDEXE%" /p:Configuration=%CONFIGURATION%;AllowUnsafeBlocks=true %MSBUILDOPT% "%PROJ%"
+"%MSBUILDEXE%" /p:Configuration=%CONFIGURATION% %MSBUILDOPT% "%PROJ%"
 @if ERRORLEVEL 1 GOTO :ErrorStop
 @echo BUILD ok for %CONFIGURATION% %PROJ%
 
@@ -71,6 +62,12 @@ if EXIST %PROJ_NAME%.nuspec (
 @echo ===== Build succeeded for %PROJ% =====
 
 @GOTO :EOF
+
+:ErrorNoCLEXE
+set RC=2
+@echo ===== WARNING: Build skipped due to missing VC++ Build Toolset. =====
+@echo ===== Build SKIPPED for %PROJ% =====
+exit /B %RC%
 
 :ErrorMSBUILD
 set RC=1

--- a/cpp/Clean.cmd
+++ b/cpp/Clean.cmd
@@ -1,0 +1,4 @@
+@ECHO OFF
+FOR /D /R . %%G IN (bin) DO @IF EXIST "%%G" (@echo RDMR /S /Q "%%G" & rd /s /q "%%G")
+FOR /D /R . %%G IN (obj) DO @IF EXIST "%%G" (@echo RDMR /S /Q "%%G" & rd /s /q "%%G")
+FOR /D /R . %%G IN (x64) DO @IF EXIST "%%G" (@echo RDMR /S /Q "%%G" & rd /s /q "%%G")

--- a/cpp/Riosock.sln
+++ b/cpp/Riosock.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30501.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Riosock", "Riosock\Riosock.vcxproj", "{9572BB3A-F6C5-4E02-BEB7-282E53F5E75C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9572BB3A-F6C5-4E02-BEB7-282E53F5E75C}.Debug|x64.ActiveCfg = Debug|x64
+		{9572BB3A-F6C5-4E02-BEB7-282E53F5E75C}.Debug|x64.Build.0 = Debug|x64
+		{9572BB3A-F6C5-4E02-BEB7-282E53F5E75C}.Release|x64.ActiveCfg = Release|x64
+		{9572BB3A-F6C5-4E02-BEB7-282E53F5E75C}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/cpp/Riosock/Locks.h
+++ b/cpp/Riosock/Locks.h
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include <windows.h>
+
+class PrioritizedLock {
+public:
+    PrioritizedLock() throw()
+    {
+        InitializeSRWLock(&srwlock);
+        InitializeCriticalSectionEx(&cs, 4000, 0);
+    }
+
+    ~PrioritizedLock() throw()
+    {
+        DeleteCriticalSection(&cs);
+    }
+
+    // taking an *exclusive* lock to interrupt the *shared* lock taken by the deque IO path
+    // - we want to interrupt the IO path so we can initiate more IO if we need to grow the CQ
+    _Acquires_exclusive_lock_(this->srwlock)
+    _Acquires_lock_(this->cs)
+    void PriorityLock() throw()
+    {
+        AcquireSRWLockExclusive(&srwlock);
+        EnterCriticalSection(&cs);
+    }
+
+    _Releases_lock_(this->cs)
+    _Releases_exclusive_lock_(this->srwlock)
+    void PriorityRelease() throw()
+    {
+        LeaveCriticalSection(&cs);
+        ReleaseSRWLockExclusive(&srwlock);
+    }
+
+    _Acquires_shared_lock_(this->srwlock)
+    _Acquires_lock_(this->cs)
+    void DefaultLock() throw()
+    {
+        AcquireSRWLockShared(&srwlock);
+        EnterCriticalSection(&cs);
+    }
+
+    _Releases_lock_(this->cs)
+    _Releases_shared_lock_(this->srwlock)
+    void DefaultRelease() throw()
+    {
+        LeaveCriticalSection(&cs);
+        ReleaseSRWLockShared(&srwlock);
+    }
+
+    /// not copyable
+    PrioritizedLock(const PrioritizedLock&) = delete;
+    PrioritizedLock& operator=(const PrioritizedLock&) = delete;
+
+private:
+    SRWLOCK srwlock;
+    CRITICAL_SECTION cs;
+};
+
+class AutoReleasePriorityLock {
+public:
+    explicit AutoReleasePriorityLock(PrioritizedLock &priorityLock) throw()
+        : prioritizedLock(priorityLock)
+    {
+        prioritizedLock.PriorityLock();
+    }
+
+    ~AutoReleasePriorityLock() throw()
+    {
+        prioritizedLock.PriorityRelease();
+    }
+
+    /// no default ctor
+    AutoReleasePriorityLock() = delete;
+    /// non-copyable
+    AutoReleasePriorityLock(const AutoReleasePriorityLock&) = delete;
+    AutoReleasePriorityLock operator=(const AutoReleasePriorityLock&) = delete;
+
+private:
+    PrioritizedLock &prioritizedLock;
+};
+
+
+class AutoReleaseDefaultLock {
+public:
+    explicit AutoReleaseDefaultLock(PrioritizedLock &priorityLock) throw() 
+        : prioritizedLock(priorityLock)
+    {
+        prioritizedLock.DefaultLock();
+    }
+
+    ~AutoReleaseDefaultLock() throw()
+    {
+        prioritizedLock.DefaultRelease();
+    }
+
+    /// no default ctor
+    AutoReleaseDefaultLock() = delete;
+    /// non-copyable
+    AutoReleaseDefaultLock(const AutoReleaseDefaultLock&) = delete;
+    AutoReleaseDefaultLock operator=(const AutoReleaseDefaultLock&) = delete;
+
+private:
+    PrioritizedLock &prioritizedLock;
+};

--- a/cpp/Riosock/Riosock.cpp
+++ b/cpp/Riosock/Riosock.cpp
@@ -1,0 +1,871 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#define WIN32_LEAN_AND_MEAN
+
+//#include "stdafx.h"
+#include <windows.h>
+#include <winsock2.h>
+#include <mswsock.h>
+#include <mstcpip.h>
+#include "RIOSock.h"
+#include <cstdlib>
+#include "Locks.h"
+#include <new>
+#include <cassert>
+
+// Need to link with Ws2_32.lib
+#pragma comment (lib, "Ws2_32.lib")
+
+const DWORD DefaultRIOCQSize = 256;
+DWORD CQSize = 0;
+DWORD CQUsed = 0;
+
+LONG RIOSockRef;
+PrioritizedLock *CQAccessLock = nullptr;
+RIO_CQ CompletionQueue = nullptr;
+RIO_RQ RequestQueue = nullptr;
+RIO_NOTIFICATION_COMPLETION CompletionType;
+RIO_EXTENSION_FUNCTION_TABLE RIOFuncs = { 0 };
+
+//
+// Local Functions
+//
+
+HRESULT EnsureWinSockMethods(_In_ SOCKET socket);
+RIO_CQ CreateRIOCompletionQueue(_In_ DWORD queueSize, _In_opt_ PRIO_NOTIFICATION_COMPLETION pNotificationCompletion);
+void CloseRIOCompletionQueue(_In_ RIO_CQ cq);
+ULONG DequeueRIOCompletion(_In_ RIO_CQ cq, _Out_writes_to_(arraySize, return) PRIORESULT array, _In_ ULONG arraySize);
+BOOL ResizeRIOCompletionQueue(_In_ RIO_CQ cq, _In_ ULONG queueSize);
+
+//+
+//  Function:
+//      EnsureWinSockMethods()
+//
+//  Description:
+//      Static function only to be called locally to ensure WSAStartup is held
+//      for the function pointers to remain accurate
+//
+//  Result:
+//      Returns a registered buffer descriptor, if no errors occurs.
+//      Otherwise, a value of RIO_INVALID_BUFFERID is returned.
+//-
+LONG WinSockMethodsLock = 0;
+HRESULT EnsureWinSockMethods(
+    _In_  SOCKET  socket
+    )
+{
+    static const LONG LockUninitialized = 0;
+    static const LONG LockInitialized = 1;
+    static const LONG LockInitializing = 2;
+
+    LONG lastState;
+
+    while((lastState = ::InterlockedCompareExchange(
+                &WinSockMethodsLock,
+                LockInitializing,
+                LockUninitialized)) == LockInitializing)
+    {
+        Sleep(0);
+    }
+    
+    if (lastState == LockInitialized)
+    {
+        return S_OK;
+    }
+
+    WSADATA wsaData;
+    auto err = WSAStartup(WINSOCK_VERSION, &wsaData);
+    if (err != 0) {
+        // Reset lock to uninitialized
+        ::InterlockedExchange(&WinSockMethodsLock, LockUninitialized);
+        // WSAStartup does not set LastWin32Error
+        SetLastError(err);
+        return HRESULT_FROM_WIN32(err);
+    }
+
+    // Check to see if we need to create a temp socket
+    auto localSocket = socket;
+    if (INVALID_SOCKET == localSocket)
+    {
+        DWORD dwFlags = WSA_FLAG_NO_HANDLE_INHERIT | WSA_FLAG_OVERLAPPED | WSA_FLAG_REGISTERED_IO;
+        localSocket = WSASocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, nullptr, 0, dwFlags);
+        if (INVALID_SOCKET == localSocket)
+        {
+            DWORD errorCode = WSAGetLastError();
+            // Reset lock to uninitialized
+            WSACleanup();
+            ::InterlockedExchange(&WinSockMethodsLock, LockUninitialized);
+            SetLastError(errorCode);
+            return HRESULT_FROM_WIN32(errorCode);
+        }
+    }
+
+    GUID funcGuid = WSAID_MULTIPLE_RIO;
+    DWORD dwBytes = 0;
+
+    if (WSAIoctl(
+            localSocket,
+            SIO_GET_MULTIPLE_EXTENSION_FUNCTION_POINTER,
+            &funcGuid, sizeof(GUID),
+            &RIOFuncs, sizeof(RIOFuncs),
+            &dwBytes,nullptr, nullptr) != 0)
+    {
+        DWORD errorCode = WSAGetLastError();
+        if (localSocket != socket)
+        {
+            closesocket(localSocket);
+        }
+
+        WSACleanup();
+        // Reset lock to uninitialized
+        ::InterlockedExchange(&WinSockMethodsLock, LockUninitialized);
+        SetLastError(errorCode);
+        return HRESULT_FROM_WIN32(errorCode);
+    }
+
+    // Update lock to fully Initialized
+    ::InterlockedExchange(&WinSockMethodsLock, LockInitialized);
+    if (localSocket != socket) {
+        closesocket(localSocket);
+    }
+    return S_OK;
+}
+
+
+//+
+//  Function:
+//      CreateRIOCompletionQueue()
+//
+//  Description:
+//      Internally, this function calls RIOCreateCompletionQueue to
+//      create a completion queue.
+//
+//  Result:
+//      Returns a RIO_CQ
+//-
+FORCEINLINE
+RIO_CQ CreateRIOCompletionQueue(
+    _In_     DWORD                         queueSize,
+    _In_opt_ PRIO_NOTIFICATION_COMPLETION  pNotificationCompletion
+    )
+{
+    auto hr = EnsureWinSockMethods(INVALID_SOCKET);
+    if (FAILED(hr))
+    {
+        return RIO_INVALID_CQ;
+    }
+    return RIOFuncs.RIOCreateCompletionQueue(queueSize, pNotificationCompletion);
+}
+
+
+//+
+//  Function:
+//      CloseRIOCompletionQueue()
+//
+//  Description:
+//      Internally, this function calls RIOCloseCompletionQueue to
+//      close a completion queue.
+//
+//  Result:
+//      None.
+//-
+FORCEINLINE
+void CloseRIOCompletionQueue(
+    _In_ RIO_CQ cq
+    )
+{
+    auto hr = EnsureWinSockMethods(INVALID_SOCKET);
+    if (FAILED(hr))
+    {
+        return;
+    }
+    RIOFuncs.RIOCloseCompletionQueue(cq);
+}
+
+
+//+
+//  Function:
+//      DequeueRIOCompletion()
+//
+//  Description:
+//      Internally, this function calls RIODequeueCompletion to
+//      remove entries from an I/O completion queue.
+//
+//  Result:
+//      Returns the number of completion entries removed from the specified completion queue. 
+//-
+FORCEINLINE
+ULONG DequeueRIOCompletion(
+    _In_                                RIO_CQ      cq,
+    _Out_writes_to_(arraySize, return)  PRIORESULT  array,
+    _In_                                ULONG       arraySize
+    )
+{
+    auto hr = EnsureWinSockMethods(INVALID_SOCKET);
+    if (FAILED(hr))
+    {
+        return RIO_CORRUPT_CQ;
+    }
+
+    return RIOFuncs.RIODequeueCompletion(cq, array, arraySize);
+}
+
+
+//+
+//  Function:
+//      ResizeRIOCompletionQueue()
+//
+//  Description:
+//      Internally, this function calls RIOResizeCompletionQueue to
+//      resizes the I/O completion queue.
+//
+//  Result:
+//      None.
+//-
+FORCEINLINE
+BOOL ResizeRIOCompletionQueue(
+    _In_  RIO_CQ cq,
+    _In_  ULONG queueSize
+    )
+{
+    auto hr = EnsureWinSockMethods(INVALID_SOCKET);
+    if (FAILED(hr))
+    {
+        return FALSE;
+    }
+    return RIOFuncs.RIOResizeCompletionQueue(cq, queueSize);
+}
+
+
+//
+// Global APIs
+//
+
+
+//+
+//  Function:
+//      RIOSockInitialize()
+//
+//  Description:
+//      This function is global initializer for RIOSock.dll and must be called
+//      before any RIOSock APIs are invoked.
+//
+//  Result:
+//      HRESULT codes.
+//-
+HRESULT RIOSOCKAPI RIOSockInitialize()
+{
+    // Return if already initialized
+    if (RIOSockRef > 0) {
+        InterlockedIncrement(&RIOSockRef);
+        return S_OK;
+    }
+
+    // Create lock for Completion Queue access
+    CQAccessLock = new (std::nothrow) PrioritizedLock;
+    if (nullptr == CQAccessLock) {
+        return E_OUTOFMEMORY;
+    }
+
+    // Create IOCP handle
+    auto iocpHandle = CreateIoCompletionPort(INVALID_HANDLE_VALUE, nullptr, 0, 0);
+    if (iocpHandle == nullptr)
+    {
+        DWORD errorCode = GetLastError();
+        delete CQAccessLock;
+        SetLastError(errorCode);
+        return HRESULT_FROM_WIN32(errorCode);
+    }
+
+    // Create OVERLAPPED
+    auto overLapped = calloc(1, sizeof(OVERLAPPED));
+    if (nullptr == overLapped) {
+        // Close IOCP handle
+        CloseHandle(iocpHandle);
+        delete CQAccessLock;
+        SetLastError(WSAENOBUFS);
+        return HRESULT_FROM_WIN32(WSAENOBUFS);
+    }
+
+    // With RIO, we don't associate the IOCP handle with the socket like 'typical' sockets
+    // - Instead we directly pass the IOCP handle through RIOCreateCompletionQueue
+    ::ZeroMemory(&CompletionType, sizeof(CompletionType));
+
+    CompletionType.Type = RIO_IOCP_COMPLETION;
+    CompletionType.Iocp.CompletionKey = reinterpret_cast<void*>(1); 
+    CompletionType.Iocp.Overlapped = overLapped;
+    CompletionType.Iocp.IocpHandle = iocpHandle;
+    
+    // Create a completion queue
+    CompletionQueue = CreateRIOCompletionQueue(DefaultRIOCQSize, &CompletionType);
+    if (RIO_INVALID_CQ == CompletionQueue) {
+        DWORD errorCode = WSAGetLastError();
+        CloseHandle(iocpHandle);
+        free(overLapped);
+        delete CQAccessLock;
+        SetLastError(errorCode);
+        return HRESULT_FROM_WIN32(errorCode);
+    }
+
+    // now that the CQ is created, update info
+    CQSize = DefaultRIOCQSize;
+    CQUsed = 0;
+
+    return S_OK;
+}
+
+
+//+
+//  Function:
+//      RIOSockUninitialize()
+//
+//  Description:
+//      This function cleans up resources allocated by RIOSockInitialize.
+//
+//  Result:
+//      None.
+//-
+void RIOSOCKAPI RIOSockUninitialize()
+{
+    InterlockedDecrement(&RIOSockRef);
+    if (RIOSockRef > 0) return;
+
+    if (CompletionQueue != RIO_INVALID_CQ) {
+        CloseRIOCompletionQueue(CompletionQueue);
+        CompletionQueue = RIO_INVALID_CQ;
+    }
+
+    if (CompletionType.Iocp.IocpHandle != nullptr) {
+        CloseHandle(CompletionType.Iocp.IocpHandle);
+        CompletionType.Iocp.IocpHandle = nullptr;
+    }
+
+    free(CompletionType.Iocp.Overlapped);
+    CompletionType.Iocp.Overlapped = nullptr;
+
+    delete CQAccessLock;
+    CQAccessLock = nullptr;
+}
+
+
+//+
+//  Function:
+//      CreateRIOSocket()
+//
+//  Description:
+//      This function creates a socket that bound to a local loop-back for use with RIO.
+//
+//  Parameters:
+//      localAddr     -  A pointer to the beginning of the memory buffer to register.
+//      localAddrLen  -  The length, in bytes, in the buffer to register.
+//
+//  Result:
+//      Returns a new socket, if no errors occurs. Otherwise, a value of INVALID_SOCKET is returned.
+//-
+SOCKET RIOSOCKAPI CreateRIOSocket(
+    _Out_    SOCKADDR  *localAddr,
+    _Inout_  int       *localAddrLen
+    )
+{
+    // DWORD dwFlags = WSA_FLAG_NO_HANDLE_INHERIT | WSA_FLAG_OVERLAPPED | WSA_FLAG_REGISTERED_IO;
+    auto socket = WSASocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, nullptr, 0, WSA_FLAG_REGISTERED_IO);
+    if (INVALID_SOCKET == socket)
+    {
+        DWORD errorCode = WSAGetLastError();
+        SetLastError(errorCode);
+        return INVALID_SOCKET;
+    }
+
+    // Enables SIO_LOOPBACK_FAST_PATH
+    auto OptionValue = 1;
+    DWORD NumberOfBytesReturned = 0;
+    if (WSAIoctl(socket,
+                 SIO_LOOPBACK_FAST_PATH,
+                 &OptionValue,
+                 sizeof(OptionValue),
+                 nullptr, 0,
+                 &NumberOfBytesReturned,
+                 nullptr, nullptr) == SOCKET_ERROR)
+    {
+        DWORD errorCode = WSAGetLastError();
+        closesocket(socket);
+        SetLastError(errorCode);
+        return INVALID_SOCKET;
+    }
+
+    // Bind socket for exclusive access
+    const BOOL bindExclUse = 1;
+    if (setsockopt(socket,
+        SOL_SOCKET,
+        SO_EXCLUSIVEADDRUSE,
+        reinterpret_cast<const char *>(&bindExclUse),
+        sizeof(bindExclUse)) == SOCKET_ERROR)
+    {
+        // Unexpected failure: report it then close our socket
+        DWORD errorCode = WSAGetLastError();
+        closesocket(socket);
+        SetLastError(errorCode);
+        return INVALID_SOCKET;
+    }
+
+    // Bind the socket to the loop-back address
+    SOCKADDR_IN sockAddr;
+    sockAddr.sin_family = AF_INET;
+    sockAddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    sockAddr.sin_port = htons(0);
+    if (bind(socket, reinterpret_cast<SOCKADDR *>(&sockAddr), sizeof(sockAddr)) == SOCKET_ERROR)
+    {
+        DWORD errorCode = WSAGetLastError();
+        closesocket(socket);
+        SetLastError(errorCode);
+        return INVALID_SOCKET;
+    }
+
+    // Retrieve the local name (addr) of the socket
+    if (getsockname(socket, localAddr, localAddrLen) == SOCKET_ERROR)
+    {
+        DWORD errorCode = WSAGetLastError();
+        closesocket(socket);
+        SetLastError(errorCode);
+        return INVALID_SOCKET;
+    }
+
+    return socket;
+}
+
+//+
+//  Function:
+//      PostRIOReceive()
+//
+//  Description:
+//      This function posts a receive operation to receives data on a connected RIO socket.
+//
+//  Parameters:
+//      socketQueue      -  The request queue that identifies a connected RIO socket.
+//      pData            -  The portion of the registered buffer in which to receive data.
+//      dataBufferCount  -  The data buffer count of the buffer pointed to by the pData parameter.
+//      flags            -  A set of flags that modify the behavior of the RIOReceive function.
+//      requestContext   -  The request context to associate with this receive operation.
+//
+//  Result:
+//      Returns true if no error occurs. Otherwise, a value of false is returned.
+//-
+FORCEINLINE
+BOOL RIOSOCKAPI PostRIOReceive(
+    _In_  RIO_RQ    socketQueue,
+    _In_  PRIO_BUF  pData,
+    _In_  ULONG     dataBufferCount,
+    _In_  DWORD     flags,
+    _In_  PVOID     requestContext
+    )
+{
+    auto hr = EnsureWinSockMethods(INVALID_SOCKET);
+    if (FAILED(hr))
+    {
+        return FALSE;
+    }
+
+    return RIOFuncs.RIOReceive(socketQueue, pData, dataBufferCount, flags, requestContext);
+}
+
+
+//+
+//  Function:
+//      PostRIOSend()
+//
+//  Description:
+//      This function posts a send operation to send data on a connected RIO socket.
+//
+//  Parameters:
+//      socketQueue      -  The request queue that identifies a connected RIO socket.
+//      pData            -  The portion of the registered buffer in which to receive data.
+//      dataBufferCount  -  The data buffer count of the buffer pointed to by the pData parameter.
+//      flags            -  A set of flags that modify the behavior of the RIOReceive function.
+//      requestContext   -  The request context to associate with this receive operation.
+//
+//  Result:
+//      Returns TRUE if no error occurs. Otherwise, a value of FALSE is returned.
+//-
+FORCEINLINE
+BOOL RIOSOCKAPI PostRIOSend(
+    _In_  RIO_RQ    socketQueue,
+    _In_  PRIO_BUF  pData,
+    _In_  ULONG     dataBufferCount,
+    _In_  DWORD     flags,
+    _In_  PVOID     requestContext
+    )
+{
+    auto hr = EnsureWinSockMethods(INVALID_SOCKET);
+    if (FAILED(hr))
+    {
+        return FALSE;
+    }
+
+    return RIOFuncs.RIOSend(socketQueue, pData, dataBufferCount, flags, requestContext);
+}
+
+
+//+
+//  Function:
+//      RegisterRIONotify()
+//
+//  Description:
+//      This function registers the method to use for notification behavior.
+//
+//  Result:
+//      Returns TRUE if no error occurs. Otherwise, a value of FALSE is returned.
+//-
+FORCEINLINE
+BOOL RIOSOCKAPI RegisterRIONotify()
+{
+    auto hr = EnsureWinSockMethods(INVALID_SOCKET);
+    if (FAILED(hr))
+    {
+        return FALSE;
+    }
+
+    auto notify = RIOFuncs.RIONotify(CompletionQueue);
+    if (notify != ERROR_SUCCESS) {
+        SetLastError(notify);
+        return FALSE;
+    }
+    return TRUE;
+}
+
+
+//+
+//  Function:
+//      RegisterRIOBuffer()
+//
+//  Description:
+//      This function registers a specified buffer for use with RIO Socket.
+//
+//  Parameters:
+//      dataBuffer  -  A pointer to the beginning of the memory buffer to register.
+//      dataLength  -  The length, in bytes, in the buffer to register.
+//
+//  Result:
+//      Returns a registered buffer descriptor, if no errors occurs.
+//      Otherwise, a value of RIO_INVALID_BUFFERID is returned.
+//-
+FORCEINLINE
+RIO_BUFFERID RIOSOCKAPI RegisterRIOBuffer(
+    _In_  PCHAR  dataBuffer,
+    _In_  DWORD  dataLength
+)
+{
+    auto hr = EnsureWinSockMethods(INVALID_SOCKET);
+    if (FAILED(hr))
+    {
+        return RIO_INVALID_BUFFERID;
+    }
+
+    return RIOFuncs.RIORegisterBuffer(dataBuffer, dataLength);
+}
+
+
+//+
+//  Function:
+//      DeregisterRIOBuffer()
+//
+//  Description:
+//      This function deregisters a registered buffer used with RIO socket.
+//
+//  Parameters:
+//      bufferId  -  A descriptor identifying a registered buffer.
+//
+//  Result:
+//      None.
+//-
+FORCEINLINE
+void RIOSOCKAPI DeregisterRIOBuffer(
+    _In_ RIO_BUFFERID bufferId
+)
+{
+    auto hr = EnsureWinSockMethods(INVALID_SOCKET);
+    if (FAILED(hr))
+    {
+        return;
+    }
+    return RIOFuncs.RIODeregisterBuffer(bufferId);
+}
+
+
+//+
+//  Function:
+//      AllocateRIOCompletion()
+//
+//  Description:
+//      This function makes rooms in the CQ for a new IO.
+//       - check if there is room in the CQ for the new IO
+//       - if not, take a writer lock around the CS to halt readers and to write to cq_used
+//         then take the CS over the CQ, and resize the CQ by 1.5 times current size
+//
+//  Parameters:
+//      numCompltetion  -  The number of completions that need to be allocated from the completion queue.
+//
+//  Result:
+//      return TRUE, if no error occurs; otherwise, FALSE.
+//-
+FORCEINLINE
+BOOL RIOSOCKAPI AllocateRIOCompletion(
+    _In_ DWORD numCompltetion
+    )
+{
+    // Taking an priority lock to interrupt the general lock taken by the deque IO path
+    // We want to interrupt the IO path so we can initiate more IO if we need to grow the CQ
+    AutoReleasePriorityLock priorityLock(*CQAccessLock);
+
+    auto newCQUsed = CQUsed + numCompltetion;
+    auto newCQSize = CQSize; // not yet resized
+    if (CQSize < newCQUsed) {
+        if (RIO_MAX_CQ_SIZE == CQSize || newCQUsed > RIO_MAX_CQ_SIZE)
+        {
+            // fail hard if we are already at the max CQ size and can't grow it for more IO
+            return FALSE;
+        }
+
+        // multiply newCQUsed by 1.25 for better growth patterns
+        newCQSize = static_cast<DWORD>(newCQUsed * 1.25);
+        if (newCQSize > RIO_MAX_CQ_SIZE) {
+            static_assert(MAXLONG / 1.25 > RIO_MAX_CQ_SIZE, "CQSize can overflow");
+            newCQSize = RIO_MAX_CQ_SIZE;
+        }
+
+        if (!ResizeRIOCompletionQueue(CompletionQueue, newCQSize))
+        {
+            return FALSE;
+        }
+    }
+
+    // update CQUsed and CQSize on the success path
+    CQUsed = newCQUsed;
+    CQSize = newCQSize;
+    return TRUE;
+}
+
+
+//+
+//  Function:
+//      ReleaseRIOCompletion()
+//
+//  Description:
+//      This function release rooms back to the CQ
+//
+//  Parameters:
+//      numCompltetion  -  The number of completions that need to be released.
+//
+//  Result:
+//      return FALSE, if numCompltetion > CQUsed; otherwise, TRUE.
+//-
+FORCEINLINE
+BOOL RIOSOCKAPI ReleaseRIOCompletion(
+    _In_ DWORD numCompletion 
+    )
+{
+    AutoReleasePriorityLock priorityLock(*CQAccessLock);
+    if (CQUsed < numCompletion)
+    {
+        return FALSE;
+    }
+
+    CQUsed -= numCompletion;
+    return TRUE;
+}
+
+
+//+
+//  Function:
+//      DequeueRIOResults()
+//
+//  Description:
+//      This function dequeue RIO results from the I/O completion queue used with RIO socket.
+//      It will always post a Notify with proper synchronization.
+//
+//  Parameters:
+//      rioResults     -  An array of RIORESULT structures to receive the description of the completions dequeued.
+//      rioResultSize  -  The maximum number of entries in the rioResults to write.
+//
+//  Result:
+//      If no error occurs, it returns the number of RIO results retrieved from the completion queue.
+//      Otherwise, a value of RIO_CORRUPT_CQ is returned to indicate that the state of the completion
+//      queue has become corrupt due to memory corruption or misuse of the RIO functions.
+//-
+FORCEINLINE
+DWORD RIOSOCKAPI DequeueRIOResults(
+    _Out_  PRIORESULT  rioResults,
+    _In_   DWORD       rioResultSize
+    )
+{
+    // Taking a lower-priority lock, to allow the priority lock to interrupt
+    // dequeuing. So it can add space to the CQ
+    AutoReleaseDefaultLock defaultLock(*CQAccessLock);
+
+    auto resultCount = DequeueRIOCompletion(CompletionQueue, rioResults, rioResultSize);
+    if (0 == resultCount || RIO_CORRUPT_CQ == resultCount)
+    {
+        // We were notified there were completions, but we can't dequeue any IO
+        // Something has gone horribly wrong - likely our CQ is corrupt.
+        return resultCount;
+    }
+
+    // Immediately after invoking Dequeue, post another Notify
+    auto notifyResult = RegisterRIONotify();
+    if (notifyResult == FALSE)
+    {
+        // if notify fails, we can't reliably know when the next IO completes
+        // this will cause everything to come to a grinding halt
+        return RIO_CORRUPT_CQ;
+    }
+
+    return resultCount;
+}
+
+
+//+
+//  Function:
+//      CreateRIORequestQueue()
+//
+//  Description:
+//      This function creates a request queue by calling RIOCreateRequestQueue.
+//
+//  Parameters:
+//      socket                 -  A socket to for the new request queue.
+//      maxOutstandingReceive  -  The maximum number of outstanding receives allowed on the socket.
+//      maxOutstandingSend     -  The maximum number of outstanding sends allowed on the socket.
+//      socketContext          -  The socket context to associate with this request queue.
+//
+//  Result:
+//      If no error occurs, it returns a new request queue. Otherwise, a value of RIO_INVALID_RQ is returned.
+//-
+FORCEINLINE
+RIO_RQ RIOSOCKAPI CreateRIORequestQueue(
+    _In_ SOCKET  socket,
+    _In_ ULONG   maxOutstandingReceive,
+    _In_ ULONG   maxOutstandingSend,
+    _In_ PVOID   socketContext
+    )
+{
+    // A request queue is associated with a socket, ensure that the client passed us a valid socket 
+    assert(socket != INVALID_SOCKET);
+
+    auto hr = EnsureWinSockMethods(socket);
+    if (FAILED(hr))
+    {
+        return RIO_INVALID_RQ;
+    }
+
+    return RIOFuncs.RIOCreateRequestQueue(
+        socket,
+        maxOutstandingReceive,
+        1,
+        maxOutstandingSend,
+        1,
+        CompletionQueue,
+        CompletionQueue,
+        socketContext
+    );
+}
+
+
+//+
+//  Function:
+//      ResizeRIORequestQueue()
+//
+//  Description:
+//      This function resizes a request queue by calling RIOResizeRequestQueue.
+//
+//  Parameters:
+//      rq                     -  A request queue to be resize.
+//      maxOutstandingReceive  -  The maximum number of outstanding receives allowed on the socket.
+//      maxOutstandingSend     -  The maximum number of outstanding sends allowed on the socket.
+//
+//  Result:
+//      If no error occurs, it returns TRUE. Otherwise, a value of FALSE is returned.
+//-
+BOOL RIOSOCKAPI ResizeRIORequestQueue(
+    _In_ RIO_RQ rq,
+    _In_ DWORD  maxOutstandingReceive,
+    _In_ DWORD  maxOutstandingSend
+)
+{
+    // ensure that the client passed us a valid RQ 
+    assert(rq != RIO_INVALID_RQ);
+
+    auto hr = EnsureWinSockMethods(INVALID_SOCKET);
+    if (FAILED(hr))
+    {
+        return FALSE;
+    }
+
+    return RIOFuncs.RIOResizeRequestQueue(rq, maxOutstandingReceive, maxOutstandingSend);
+}
+
+
+//+
+//  Function:
+//      GetRIOCompletionStatus()
+//
+//  Description:
+//      This function calls GetQueuedCompletionStatus() internally to dequeue an IO completion packet.
+//      If there is no completion packet queued, the function blocks the thread.
+//
+//  Result:
+//      If no error occurs, it returns a new request queue. Otherwise, a value of RIO_INVALID_RQ is returned.
+//-
+FORCEINLINE
+BOOL RIOSOCKAPI GetRIOCompletionStatus()
+{
+    DWORD bytesTransferred;
+    ULONG_PTR completionKey;
+    OVERLAPPED *pov = nullptr;
+
+
+    if (!GetQueuedCompletionStatus(
+            CompletionType.Iocp.IocpHandle,
+            &bytesTransferred,
+            &completionKey,
+            &pov,
+            INFINITE))
+    {
+        auto lastError = GetLastError();
+        SetLastError(lastError);
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+
+//////////////////////////////////////////////////////////////////////////
+
+
+//+
+// DLL Entry
+//-
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD dwReason, LPVOID lpReserved)
+{
+    UNREFERENCED_PARAMETER(lpReserved);
+    if (dwReason == DLL_PROCESS_ATTACH)
+    {
+        // Initializes use of Winsock 2 DLL
+        WSADATA wsaData;
+        if (WSAStartup(WINSOCK_VERSION, &wsaData) != 0)
+        {
+            return FALSE;
+        }
+
+        // Disables the DLL_THREAD_ATTACH and DLL_THREAD_DETACH notifications 
+        DisableThreadLibraryCalls(hModule);
+        return TRUE;
+    }
+
+    if (dwReason == DLL_PROCESS_DETACH)
+    {
+        // Terminates use of the Winsock 2 DLL
+        WSACleanup();
+    }
+
+    return TRUE;
+}

--- a/cpp/Riosock/Riosock.h
+++ b/cpp/Riosock/Riosock.h
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    
+#ifdef RIOSOCK_DLL
+#define RIOSOCKAPI __declspec(dllexport) __stdcall
+#else
+#define RIOSOCKAPI __declspec(dllimport) __stdcall
+#endif
+
+    //
+    // Global Routings
+    //
+
+    // Global initializer for RIOSock.dll
+    HRESULT RIOSOCKAPI RIOSockInitialize();
+
+    // Cleans up resources allocated by RIOSockInitialize.
+    void RIOSOCKAPI RIOSockUninitialize();
+
+    //
+    // Operations
+    //
+
+    // Creates a socket that bound to a local loop-back for use with RIO.
+    SOCKET RIOSOCKAPI CreateRIOSocket(
+        _Out_   SOCKADDR  *localAddr,
+        _Inout_ int       *addrLen
+        );
+
+    // Posts a receive operation to receives data on a connected RIO socket.
+    BOOL RIOSOCKAPI PostRIOReceive(
+        _In_  RIO_RQ    socketQueue,
+        _In_  PRIO_BUF  pData,
+        _In_  ULONG     dataBufferCount,
+        _In_  DWORD     flags,
+        _In_  PVOID     requestContext
+        );
+
+    // Posts a send operation to send data on a connected RIO socket.
+    BOOL RIOSOCKAPI PostRIOSend(
+        _In_  RIO_RQ    socketQueue,
+        _In_  PRIO_BUF  pData,
+        _In_  ULONG     dataBufferCount,
+        _In_  DWORD     flags,
+        _In_  PVOID     requestContext
+        );
+
+    // Registers the method to use for notification behavior.
+    BOOL RIOSOCKAPI RegisterRIONotify();
+    
+    // Registers a specified buffer for use with RIO Socket
+    RIO_BUFFERID RIOSOCKAPI RegisterRIOBuffer(
+        _In_  PCHAR  dataBuffer,
+        _In_  DWORD  dataLength
+        );
+
+    // Deregisters a registered buffer used with RIO socket.
+    void RIOSOCKAPI DeregisterRIOBuffer(
+        _In_  RIO_BUFFERID  bufferId
+        );
+
+    // Makes rooms in the completion queue for a new IO.
+    BOOL RIOSOCKAPI AllocateRIOCompletion(
+        _In_  DWORD  numCompltetion
+        );
+
+    // Release rooms in the completion queue
+    BOOL RIOSOCKAPI ReleaseRIOCompletion(
+        _In_  DWORD  numCompletion
+        );
+
+    // Dequeues RIO results from the I/O completion queue used with RIO socket.
+    DWORD RIOSOCKAPI DequeueRIOResults(
+        _Out_  PRIORESULT  rioResults,
+        _In_   DWORD       rioResultSize
+        );
+
+    // Creates a request queue
+    RIO_RQ RIOSOCKAPI CreateRIORequestQueue(
+        _In_ SOCKET  socket,
+        _In_ ULONG   maxOutstandingReceive,
+        _In_ ULONG   maxOutstandingSend,
+        _In_ PVOID   socketContext
+        );
+
+    // Resizes a request queue
+    BOOL RIOSOCKAPI ResizeRIORequestQueue(
+        _In_ RIO_RQ rq,
+        _In_ DWORD  maxOutstandingReceive,
+        _In_ DWORD  maxOutstandingSend
+        );
+
+    // Dequeues an IO completion packet
+    BOOL RIOSOCKAPI GetRIOCompletionStatus();
+
+#ifdef __cplusplus
+}
+#endif

--- a/cpp/Riosock/Riosock.vcxproj
+++ b/cpp/Riosock/Riosock.vcxproj
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{9572BB3A-F6C5-4E02-BEB7-282E53F5E75C}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>Riosock</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>RIOSOCK_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;RIOSOCK_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="Locks.h" />
+    <ClInclude Include="Riosock.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Riosock.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Adapter.csproj
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Adapter.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>Microsoft.Spark.CSharp.Adapter</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <CppDll Condition="Exists('..\..\..\cpp\x64')">HasCpp</CppDll>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -23,6 +24,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <DocumentationFile>..\documentation\Microsoft.Spark.CSharp.Adapter.Doc.XML</DocumentationFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -84,8 +86,17 @@
     <Compile Include="Interop\Ipc\JvmObjectReference.cs" />
     <Compile Include="Interop\Ipc\PayloadHelper.cs" />
     <Compile Include="Interop\Ipc\SerDe.cs" />
+    <Compile Include="Network\ByteBuf.cs" />
+    <Compile Include="Network\ByteBufChunk.cs" />
+    <Compile Include="Network\ByteBufChunkList.cs" />
+    <Compile Include="Network\ByteBufPool.cs" />
     <Compile Include="Network\DefaultSocketWrapper.cs" />
     <Compile Include="Network\ISocketWrapper.cs" />
+    <Compile Include="Network\RioNative.cs" />
+    <Compile Include="Network\RioSocketWrapper.cs" />
+    <Compile Include="Network\SaeaSocketWrapper.cs" />
+    <Compile Include="Network\SocketStream.cs" />
+    <Compile Include="Network\SockDataToken.cs" />
     <Compile Include="Network\SocketFactory.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Proxy\IDataFrameNaFunctionsProxy.cs" />
@@ -141,7 +152,18 @@
     <Compile Include="Streaming\StreamingContext.cs" />
     <Compile Include="Streaming\TransformedDStream.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup Condition=" '$(CppDll)' == 'HasCpp' ">
+    <ContentWithTargetPath Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Cpp\Riosock.dll</Link>
+      <TargetPath>Riosock.dll</TargetPath>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.pdb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Cpp\Riosock.dll</Link>
+      <TargetPath>Riosock.pdb</TargetPath>
+    </ContentWithTargetPath>
+  </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Configuration/ConfigurationService.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Configuration/ConfigurationService.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Spark.CSharp.Configuration
         public const string ProcFileName = "CSharpWorker.exe";
         public const string CSharpWorkerPathSettingKey = "CSharpWorkerPath";
         public const string CSharpBackendPortNumberSettingKey = "CSharpBackendPortNumber";
+        public const string CSharpSocketTypeEnvName = "spark.mobius.CSharp.socketType";
         public const string SPARKCLR_HOME = "SPARKCLR_HOME";
         public const string SPARK_MASTER = "spark.master";
         public const string CSHARPBACKEND_PORT = "CSHARPBACKEND_PORT";
@@ -169,9 +170,11 @@ namespace Microsoft.Spark.CSharp.Configuration
         private class SparkCLRDebugConfiguration : SparkCLRLocalConfiguration
         {
             private readonly ILoggerService logger = LoggerServiceFactory.GetLogger(typeof(SparkCLRDebugConfiguration));
+
             internal SparkCLRDebugConfiguration(System.Configuration.Configuration configuration)
                 : base(configuration)
-            {}
+            {
+            }
 
             internal override int GetPortNumber()
             {

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Configuration/IConfigurationService.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Configuration/IConfigurationService.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Microsoft.Spark.CSharp.Configuration
 {
     /// <summary>

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Interop/Ipc/WeakObjectManager.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Interop/Ipc/WeakObjectManager.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Spark.CSharp.Interop.Ipc
 
     /// <summary>
     /// adaptively control the number of weak objects that should be checked for each interval
-    /// <summary>
+    /// </summary>
     internal class WeakReferenceCheckCountController
     {
         private static readonly ILoggerService logger = LoggerServiceFactory.GetLogger(typeof(WeakReferenceCheckCountController));

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Network/ByteBuf.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Network/ByteBuf.cs
@@ -1,0 +1,401 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace Microsoft.Spark.CSharp.Network
+{
+    /// <summary>
+    /// ByteBuf delimits a section of a ByteBufChunk.
+    /// It is the smallest unit to be allocated.
+    /// </summary>
+    internal class ByteBuf
+    {
+        private int readerIndex;
+        private int writerIndex;
+
+        /// <summary>
+        /// Indicates the state of that the ByteBuf as socket data transport.
+        /// </summary>
+        public int Status;
+
+        /// <summary>
+        /// We borrow some ideas from Netty's ByteBuf. 
+        /// ByteBuf provides two pointer variables to support sequential read and write operations
+        ///  - readerIndex for a read operation and writerIndex for a write operation respectively.
+        /// The following diagram shows how a buffer is segmented into three areas by the two
+        /// pointers:
+        /// 
+        ///      +-------------------+------------------+------------------+
+        ///      | discardable bytes |  readable bytes  |  writable bytes  |
+        ///      |                   |     (CONTENT)    |                  |
+        ///      +-------------------+------------------+------------------+
+        ///      |                   |                  |                  |
+        ///      0       ==     readerIndex   ==   writerIndex    ==    capacity
+        /// </summary>
+        internal ByteBuf(ByteBufChunk chunk, int offset, int capacity)
+        {
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException("offset", "Offset is less than zero.");
+            if (capacity < 0)
+                throw new ArgumentOutOfRangeException("capacity", "Count is less than zero.");
+            if (chunk == null)
+                throw new ArgumentNullException("chunk");
+            if (chunk.Size - offset < capacity)
+                throw new ArgumentException(
+                    "Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
+
+            Capacity = capacity;
+            Offset = offset;
+            ByteBufChunk = chunk;
+            readerIndex = writerIndex = 0;
+            Status = 0;
+        }
+
+        private ByteBuf(int errorStatus)
+        {
+            Status = errorStatus;
+            Capacity = 0;
+            Offset = 0;
+            ByteBufChunk = null;
+            readerIndex = writerIndex = 0;
+        }
+
+        /// <summary>
+        /// Gets the underlying array.
+        /// </summary>
+        public byte[] Array { get { return ByteBufChunk.Array; } }
+
+        /// <summary>
+        /// Gets the total number of elements in the range delimited by the ByteBuf.
+        /// </summary>
+        public int Capacity { get; private set; }
+
+        /// <summary>
+        /// Gets the position of the first element in the range delimited
+        /// by the ByteBuf, relative to the start of the original array.
+        /// </summary>
+        public int Offset { get; private set; }
+
+        /// <summary>
+        /// Returns the ByteBuf chunk that contains this ByteBuf.
+        /// </summary>
+        internal ByteBufChunk ByteBufChunk { get; private set; }
+
+        /// <summary>
+        /// Returns the number of readable bytes which is equal to (writerIndex - readerIndex).
+        /// </summary>
+        public int ReadableBytes { get { return WriterIndex - ReaderIndex; } }
+
+        /// <summary>
+        /// Returns the number of writable bytes which is equal to (capacity - writerIndex).
+        /// </summary>
+        public int WritableBytes { get { return Capacity - WriterIndex; } }
+
+        /// <summary>
+        /// Gets the underlying unsafe array.
+        /// </summary>
+        public IntPtr UnsafeArray { get { return ByteBufChunk.UnsafeArray; } }
+
+        /// <summary>
+        /// Gets or sets the readerIndex of this ByteBuf
+        /// </summary>
+        /// <exception cref="IndexOutOfRangeException"></exception>
+        public int ReaderIndex
+        {
+            get { return readerIndex; }
+            set
+            {
+                if (value < 0 || value > WriterIndex)
+                {
+                    throw new IndexOutOfRangeException(string.Format(
+                        "ReaderIndex: {0} (expected: 0 <= readerIndex <= writerIndex({1})", value, writerIndex));
+                }
+                readerIndex = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the writerIndex of this ByteBuf
+        /// </summary>
+        /// <exception cref="IndexOutOfRangeException"></exception>
+        public int WriterIndex
+        {
+            get { return writerIndex; }
+            set
+            {
+                if (value < ReaderIndex || value > Capacity)
+                {
+                    throw new IndexOutOfRangeException(string.Format(
+                        "WriterIndex: {0}  (expected: 0 <= readerIndex({1}) <= writerIndex <= capacity ({2})", value, ReaderIndex, Capacity));
+                }
+                writerIndex = value;
+            }
+        }
+
+        /// <summary>
+        /// Returns the position of the readerIndex element in the range delimited
+        /// by the ByteBuf, relative to the start of the original array.
+        /// </summary>
+        public int ReaderIndexOffset { get { return Idx(readerIndex); } }
+
+        /// <summary>
+        /// Returns the position of the readerIndex element in the range delimited
+        /// by the ByteBuf, relative to the start of the original array.
+        /// </summary>
+        public int WriterIndexOffset { get { return Idx(writerIndex); } }
+
+        /// <summary>
+        /// Sets the readerIndex and writerIndex of this buffer to 0.
+        /// </summary>
+        public void Clear()
+        {
+            readerIndex = writerIndex = 0;
+        }
+
+        /// <summary>
+        /// Is this ByteSegment readable if and only if the buffer contains equal or more than
+        /// the specified number of elements
+        /// </summary>
+        /// <param name="size">
+        /// The number of elements we would like to read,
+        /// The default value is 1 that is to check this ByteBuf has at least 1 byte can be read.
+        /// </param>
+        /// <returns>true, if it is readable; otherwise, false</returns>
+        public bool IsReadable(int size = 1)
+        {
+            if (ByteBufChunk == null || ByteBufChunk.IsDisposed)
+            {
+                return false;
+            }
+
+            return ReadableBytes >= size;
+        }
+
+        /// <summary>
+        ///     Returns true if and only if the buffer has enough Capacity to accommodate size
+        ///     additional bytes.
+        /// </summary>
+        /// <param name="size">
+        /// The number of additional elements we would like to write
+        /// The default value is 1 that is to check this ByteBuf has at least 1 byte can be wroten.
+        /// </param>
+        /// <returns>true, if this ByteSegment is writable; otherwise, false</returns>
+        public bool IsWritable(int size = 1)
+        {
+            if (ByteBufChunk == null || ByteBufChunk.IsDisposed)
+            {
+                return false;
+            }
+
+            return WritableBytes >= size;
+        }
+
+        /// <summary>
+        /// Gets a byte at the current readerIndex and increases the readerIndex by 1 in this buffer.
+        /// </summary>
+        public byte ReadByte()
+        {
+            CheckReadableBytes(1);
+            var b = ByteBufChunk.IsUnsafe
+                ? Marshal.ReadByte(ByteBufChunk.UnsafeArray, ReaderIndexOffset)
+                : ByteBufChunk.Array[ReaderIndexOffset];
+            ReaderIndex += 1;
+            return b;
+        }
+
+        /// <summary>
+        /// Reads a block of bytes from the ByteBuf and writes the data to a buffer.
+        /// </summary>
+        /// <param name="buffer">
+        /// When this method returns, contains the specified byte array with the values
+        /// between offset and (offset + count - 1) replaced by the characters read
+        ///  from the ByteBuf. 
+        /// </param>
+        /// <param name="offset">The zero-based byte offset in buffer at which to begin storing data from the ByteBuf.</param>
+        /// <param name="count">The maximum number of bytes to read.</param>
+        /// <returns></returns>
+        public unsafe int ReadBytes(byte[] buffer, int offset, int count)
+        {
+            if (buffer == null)
+                throw new ArgumentNullException("buffer", "Buffer cannot be null.");
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException("offset", "Offset is less than zero.");
+            if (count < 0)
+                throw new ArgumentOutOfRangeException("count", "Count is less than zero.");
+            if (buffer.Length - offset < count)
+                throw new ArgumentException("Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
+
+            EnsureAccessible();
+            CheckReadableBytes(count);
+
+            int n = WriterIndex - ReaderIndex;
+            if (n > count) n = count;
+            if (n <= 0) return 0;
+
+            if (ByteBufChunk.IsUnsafe)
+            {
+                fixed (byte* pBuf = &buffer[offset])
+                {
+                    memcpy((IntPtr)pBuf, ByteBufChunk.UnsafeArray + ReaderIndexOffset, (ulong)n);
+                }
+            }
+            else
+            {
+                Buffer.BlockCopy(ByteBufChunk.Array, ReaderIndexOffset, buffer, offset, n);
+            }
+
+            ReaderIndex += n;
+            return n;
+        }
+
+        /// <summary>
+        /// Release the ByteBuf back to the ByteBufPool
+        /// </summary>
+        public void Release()
+        {
+            if (ByteBufChunk == null || ByteBufChunk.IsDisposed)
+            {
+                return;
+            }
+
+            var byteBufPool = ByteBufChunk.Pool;
+            byteBufPool.Free(this);
+            ByteBufChunk = null;
+        }
+
+        /// <summary>
+        /// Writes a block of bytes to the ByteBuf using data read from a buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to write data from. </param>
+        /// <param name="offset">The zero-based byte offset in buffer at which to begin copying bytes to the ByteBuf.</param>
+        /// <param name="count">The maximum number of bytes to write.</param>
+        public unsafe void WriteBytes(byte[] buffer, int offset, int count)
+        {
+            // Check parameters
+            if (buffer == null)
+                throw new ArgumentNullException("buffer", "Buffer cannot be null.");
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException("offset", "Offset is less than zero.");
+            if (count < 0)
+                throw new ArgumentOutOfRangeException("count", "Count is less than zero.");
+            if (buffer.Length - offset < count)
+                throw new ArgumentException(
+                    "Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
+
+            EnsureAccessible();
+            EnsureWritable(count);
+
+            if (ByteBufChunk.IsUnsafe)
+            {
+                fixed (byte* pBuf = &buffer[offset])
+                {
+                    memcpy(ByteBufChunk.UnsafeArray + WriterIndexOffset, (IntPtr)pBuf, (ulong) count);
+                }
+            }
+            else
+            {
+                Buffer.BlockCopy(buffer, offset, ByteBufChunk.Array, WriterIndexOffset, count);
+            }
+
+            WriterIndex += count;
+        }
+
+        /// <summary>
+        /// Returns a RioBuf object for input (receive)
+        /// </summary>
+        /// <returns>A RioBuf object</returns>
+        internal RioBuf GetInputRioBuf()
+        {
+            EnsureAccessible();
+            if (!ByteBufChunk.IsUnsafe)
+            {
+                throw new InvalidOperationException("Managed ByteSegment does not support RioBuf.");
+            }
+
+            return new RioBuf(ByteBufChunk.BufId, (uint)WriterIndexOffset, (uint)WritableBytes);
+        }
+
+        /// <summary>
+        /// Returns a RioBuf object for output (send).
+        /// </summary>
+        /// <returns>A RioBuf object</returns>
+        internal RioBuf GetOutputRioBuf()
+        {
+            EnsureAccessible();
+            if (!ByteBufChunk.IsUnsafe)
+            {
+                throw new InvalidOperationException("Managed ByteSegment does not support RioBuf.");
+            }
+
+            return new RioBuf(ByteBufChunk.BufId, (uint)ReaderIndexOffset, (uint)ReadableBytes);
+        }
+
+        /// <summary>
+        /// Creates an empty ByteBuf with error status.
+        /// </summary>
+        internal static ByteBuf NewErrorStatusByteBuf(int errorCode)
+        {
+            return new ByteBuf(errorCode);
+        }
+
+        private void CheckReadableBytes(int minimumReadableBytes)
+        {
+            EnsureAccessible();
+            if (ReaderIndex > WriterIndex - minimumReadableBytes)
+            {
+                throw new IndexOutOfRangeException(string.Format(
+                    "readerIndex({0}) + length({1}) exceeds writerIndex({2})", ReaderIndex, minimumReadableBytes, WriterIndex));
+            }
+        }
+
+        private void EnsureAccessible()
+        {
+            if (ByteBufChunk == null || ByteBufChunk.IsDisposed)
+            {
+                throw new ObjectDisposedException("ByteBufChunk");
+            }
+        }
+
+        private void EnsureWritable(int minWritableBytes)
+        {
+            EnsureAccessible();
+            if (minWritableBytes <= WritableBytes)
+            {
+                return;
+            }
+
+            if (minWritableBytes > Capacity - WriterIndex)
+            {
+                throw new IndexOutOfRangeException(string.Format(
+                    "writerIndex({0}) + minWritableBytes({1}) exceeds Capacity({2})", WriterIndex, minWritableBytes, Capacity));
+            }
+        }
+
+        private int Idx(int index)
+        {
+            return Offset + index;
+        }
+
+        [DllImport("msvcrt.dll", EntryPoint = "memcpy", CallingConvention = CallingConvention.Cdecl, SetLastError = false)]
+        [SuppressUnmanagedCodeSecurity]
+        private static extern IntPtr memcpy(IntPtr dest, IntPtr src, ulong count);
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct RioBuf
+    {
+        public RioBuf(IntPtr bufferId, uint offset, uint length)
+        {
+            BufferId = bufferId;
+            Offset = offset;
+            Length = length;
+        }
+
+        public readonly IntPtr BufferId;
+        public readonly uint Offset;
+        public uint Length;
+    }
+}

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Network/ByteBufChunk.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Network/ByteBufChunk.cs
@@ -1,0 +1,347 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Text;
+
+namespace Microsoft.Spark.CSharp.Network
+{
+    /// <summary>
+    /// ByteBufChunk represents a memory blocks that can be allocated from 
+    /// .Net heap (managed code) or process heap(unsafe code)
+    /// </summary>
+    internal sealed class ByteBufChunk
+    {
+        private readonly Queue<Segment> segmentQueue;
+        private readonly int segmentSize;
+        private bool disposed;
+        private byte[] memory;
+        private IntPtr unsafeMemory;
+
+        /// <summary>
+        /// The ByteBufChunkList that contains this ByteBufChunk
+        /// </summary>
+        public ByteBufChunkList Parent;
+
+        /// <summary>
+        /// The previous ByteBufChunk in linked like list
+        /// </summary>
+        public ByteBufChunk Prev;
+
+        /// <summary>
+        /// The next ByteBufChunk in linked like list
+        /// </summary>
+        public ByteBufChunk Next;
+
+        private ByteBufChunk(ByteBufPool pool, int segmentSize, int chunkSize)
+        {
+            Pool = pool;
+            FreeBytes = chunkSize;
+            Size = chunkSize;
+            this.segmentSize = segmentSize;
+
+            segmentQueue = new Queue<Segment>();
+            var numSegment = chunkSize / segmentSize;
+            for (var i = 0; i < numSegment; i++)
+            {
+                segmentQueue.Enqueue(new Segment(i * segmentSize, segmentSize));
+            }
+        }
+
+        private ByteBufChunk(ByteBufPool pool, byte[] memory, int segmentSize, int chunkSize)
+            : this(pool, segmentSize, chunkSize)
+        {
+            if (memory == null || chunkSize == 0)
+            {
+                throw new ArgumentNullException("memory", "Must be initialized with a valid byte array");
+            }
+
+            IsUnsafe = false;
+            this.memory = memory;
+            unsafeMemory = IntPtr.Zero;
+            BufId = IntPtr.Zero;
+        }
+
+        private ByteBufChunk(ByteBufPool pool, IntPtr memory, IntPtr bufId, int segmentSize, int chunkSize)
+            : this(pool, segmentSize, chunkSize)
+        {
+            if (memory == IntPtr.Zero || chunkSize == 0)
+            {
+                throw new ArgumentNullException("memory", "Must be initialized with a valid heap block.");
+            }
+
+            IsUnsafe = true;
+            unsafeMemory = memory;
+            this.memory = null;
+            BufId = bufId;
+        }
+
+        /// <summary>
+        /// Finalizer.
+        /// </summary>
+        ~ByteBufChunk()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Returns the underlying array that is used for managed code.
+        /// </summary>
+        public byte[] Array { get { return memory; } }
+
+        /// <summary>
+        /// Returns the buffer Id that registered as RIO buffer.
+        /// Only apply to unsafe ByteBufChunk
+        /// </summary>
+        public IntPtr BufId { get; private set; }
+
+        /// <summary>
+        /// Returns the unused bytes in this chunk.
+        /// </summary>
+        public int FreeBytes { get; private set; }
+
+        /// <summary>
+        /// Indicates whether this ByteBufChunk is disposed.
+        /// </summary>
+        public bool IsDisposed { get { return disposed; } }
+
+        /// <summary>
+        /// Indicates whether the underlying buffer array is a unsafe type array.
+        /// The unsafe array is used for PInvoke with native code.
+        /// </summary>
+        public bool IsUnsafe { get; private set; }
+
+        /// <summary>
+        /// Returns the ByteBufPool that this ByteBufChunk belongs to.
+        /// </summary>
+        public ByteBufPool Pool { get; private set; }
+
+        /// <summary>
+        /// Returns the size of the ByteBufChunk
+        /// </summary>
+        public int Size { get; private set; }
+
+        /// <summary>
+        /// Returns the percentage of the current usage of the chunk
+        /// </summary>
+        public int Usage
+        {
+            get
+            {
+                var bytes = FreeBytes;
+                if (bytes == 0)
+                {
+                    return 100;
+                }
+
+                var freePercentage = (int)(bytes * 100L / Size);
+                if (freePercentage == 0)
+                {
+                    return 99;
+                }
+                return 100 - freePercentage;
+            }
+        }
+
+        /// <summary>
+        /// Returns the IntPtr that points to beginning of the cached heap block.
+        /// This is used for PInvoke with native code.
+        /// </summary>
+        public IntPtr UnsafeArray { get { return unsafeMemory;} }
+
+        /// <summary>
+        /// Allocates a ByteBuf from this ByteChunk.
+        /// </summary>
+        /// <param name="byteBuf">The ByteBuf be allocated</param>
+        /// <returns>true, if succeed to allocate a ByteBuf; otherwise, false</returns>
+        public bool Allocate(out ByteBuf byteBuf)
+        {
+            if (segmentQueue.Count > 0)
+            {
+                var segment = segmentQueue.Dequeue();
+                FreeBytes -= segmentSize;
+                byteBuf = new ByteBuf(this, segment.Offset, segment.Count);
+                return true;
+            }
+
+            byteBuf = default(ByteBuf);
+            return false;
+        }
+
+        /// <summary>
+        /// Release all resources
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        /// <summary>
+        /// Releases the ByteBuf back to this ByteChunk
+        /// </summary>
+        /// <param name="byteBuf">The ByteBuf to be released.</param>
+        public void Free(ByteBuf byteBuf)
+        {
+            segmentQueue.Enqueue(new Segment(byteBuf.Offset, byteBuf.Capacity));
+            FreeBytes += segmentSize;
+        }
+
+        /// <summary>
+        /// Returns a readable string for the ByteBufChunk
+        /// </summary>
+        public override string ToString()
+        {
+            return new StringBuilder()
+                .Append("Chunk(")
+                .Append(RuntimeHelpers.GetHashCode(this).ToString("X"))
+                .Append(": ")
+                .Append(Usage)
+                .Append("%, ")
+                .Append(Size - FreeBytes)
+                .Append('/')
+                .Append(Size)
+                .Append(')')
+                .ToString();
+        }
+
+        /// <summary>
+        /// Static method to create a new ByteBufChunk with given segment and chunk size.
+        /// If isUnsafe is true, it allocates memory from the process's heap.
+        /// </summary>
+        /// <param name="pool">The ByteBufPool that contains the new ByteChunk</param>
+        /// <param name="segmentSize">The segment size</param>
+        /// <param name="chunkSize">The chunk size to create</param>
+        /// <param name="isUnsafe">Indicates if it is a safe or unsafe</param>
+        /// <returns>The new ByteBufChunk object</returns>
+        [SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage")]
+        [SuppressUnmanagedCodeSecurity]
+        public static ByteBufChunk NewChunk(ByteBufPool pool, int segmentSize, int chunkSize, bool isUnsafe)
+        {
+            ByteBufChunk chunk = null;
+            if (!isUnsafe)
+            {
+                chunk = new ByteBufChunk(pool, new byte[chunkSize], segmentSize, chunkSize);
+                return chunk;
+            }
+
+            // allocate buffers from process heap
+            var token = HeapAlloc(GetProcessHeap(), 0, chunkSize);
+            if (token == IntPtr.Zero)
+            {
+                throw new OutOfMemoryException();
+            }
+
+            // register this heap buffer to RIO buffer
+            var bufferId = RioNative.RegisterRIOBuffer(token, (uint)chunkSize);
+            if (bufferId == IntPtr.Zero)
+            {
+                FreeToProcessHeap(token);
+                throw new Exception("Failed to register RIO buffer");
+            }
+
+            try
+            {
+                chunk = new ByteBufChunk(pool, token, bufferId, segmentSize, chunkSize);
+                token = IntPtr.Zero;
+                bufferId = IntPtr.Zero;
+                return chunk;
+            }
+            finally
+            {
+                if (chunk == null && token != IntPtr.Zero)
+                {
+                    if (bufferId != IntPtr.Zero)
+                    {
+                        RioNative.DeregisterRIOBuffer(bufferId);
+                    }
+                    FreeToProcessHeap(token);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Wraps HeapFree to process heap.
+        /// </summary>
+        [SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage")]
+        [SuppressUnmanagedCodeSecurity]
+        internal static void FreeToProcessHeap(IntPtr heapBlock)
+        {
+            Debug.Assert(heapBlock != IntPtr.Zero);
+            HeapFree(GetProcessHeap(), 0, heapBlock);
+        }
+
+        /// <summary>
+        ///     Implementation of the Dispose pattern.
+        /// </summary>
+        private void Dispose(bool disposing)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            if (!IsUnsafe && memory != null)
+            {
+                memory = null;
+                segmentQueue.Clear();
+            }
+
+            if (BufId != IntPtr.Zero)
+            {
+                RioNative.DeregisterRIOBuffer(BufId);
+            }
+
+            // If the unsafedMemory is still valid, free it.
+            if (unsafeMemory != IntPtr.Zero)
+            {
+                var heapBlock = unsafeMemory;
+                unsafeMemory = IntPtr.Zero;
+                FreeToProcessHeap(heapBlock);
+            }
+
+            if (disposing)
+            {
+                GC.SuppressFinalize(this);
+            }
+
+            disposed = true;
+        }
+
+        /// <summary>
+        /// Segment struct delimits a section of a byte chunk.
+        /// </summary>
+        private struct Segment
+        {
+            public Segment(int offset, int count)
+            {
+                Offset = offset;
+                Count = count;
+            }
+
+            public readonly int Count;
+            public readonly int Offset;
+        }
+        
+        #region PInvoke
+
+        [SuppressUnmanagedCodeSecurity]
+        [DllImport("Kernel32.dll", CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Unicode)]
+        private static extern IntPtr HeapAlloc(IntPtr heapHandle, int flags, int size);
+
+        [SuppressUnmanagedCodeSecurity]
+        [DllImport("Kernel32.dll", CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Unicode)]
+        private static extern void HeapFree(IntPtr heapHandle, int flags, IntPtr freePtr);
+
+        [SuppressUnmanagedCodeSecurity]
+        [DllImport("Kernel32.dll", CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Unicode)]
+        private static extern IntPtr GetProcessHeap();
+
+        #endregion
+    }
+}

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Network/ByteBufChunkList.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Network/ByteBufChunkList.cs
@@ -1,0 +1,213 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Text;
+
+namespace Microsoft.Spark.CSharp.Network
+{
+    /// <summary>
+    /// ByteBufChunkList class represents a simple linked like list used to store ByteBufChunk objects
+    /// based on its usage.
+    /// </summary>
+    internal class ByteBufChunkList
+    {
+        private readonly int maxUsage;
+        private readonly int minUsage;
+
+        internal readonly ByteBufChunkList NextList;
+        internal ByteBufChunk head;
+
+        /// <summary>
+        /// The previous ByteBufChunkList. This is only update once when create the linked like list
+        /// of ByteBufChunkList in ByteBufPool constructor.
+        /// </summary>
+        public ByteBufChunkList PrevList;
+
+        /// <summary>
+        /// Initializes a ByteBufChunkList instance with the next ByteBufChunkList and minUsage and maxUsage
+        /// </summary>
+        /// <param name="nextList">The next item of this ByteBufChunkList</param>
+        /// <param name="minUsage">The definition of minimum usage to contain ByteBufChunk</param>
+        /// <param name="maxUsage">The definition of maximum usage to contain ByteBufChunk</param>
+        public ByteBufChunkList(ByteBufChunkList nextList, int minUsage, int maxUsage)
+        {
+            NextList = nextList;
+            this.minUsage = minUsage;
+            this.maxUsage = maxUsage;
+        }
+
+        /// <summary>
+        /// Add the ByteBufChunk to this ByteBufChunkList linked-list based on ByteBufChunk's usage.
+        /// So it will be moved to the right ByteBufChunkList that has the correct minUsage/maxUsage.
+        /// </summary>
+        /// <param name="chunk">The ByteBufChunk to be added</param>
+        public void Add(ByteBufChunk chunk)
+        {
+            if (chunk.Usage >= maxUsage)
+            {
+                NextList.Add(chunk);
+                return;
+            }
+
+            AddInternal(chunk);
+        }
+
+        /// <summary>
+        /// Allocates a ByteBuf from this ByteBufChunkList if it is not empty.
+        /// </summary>
+        /// <param name="byteBuf">The allocated ByteBuf</param>
+        /// <returns>true, if the ByteBuf be allocated; otherwise, false.</returns>
+        public bool Allocate(out ByteBuf byteBuf)
+        {
+            if (head == null)
+            {
+                // This ByteBufChunkList is empty
+                byteBuf = default(ByteBuf);
+                return false;
+            }
+
+            for (var cur = head; ;)
+            {
+                if (!cur.Allocate(out byteBuf))
+                {
+                    cur = cur.Next;
+                    if (cur == null)
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    if (cur.Usage < maxUsage) return true;
+
+                    Remove(cur);
+                    NextList.Add(cur);
+                    return true;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Releases the segment back to its ByteBufChunk.
+        /// </summary>
+        /// <param name="chunk">The ByteBufChunk that contains the ByteBuf</param>
+        /// <param name="byteBuf">The ByteBuf to be released.</param>
+        /// <returns>
+        /// true, if the ByteBuf be released and NOT need to destroy the
+        /// ByteBufChunk (its usage is 0); otherwise, false.
+        /// </returns>
+        public bool Free(ByteBufChunk chunk, ByteBuf byteBuf)
+        {
+            chunk.Free(byteBuf);
+            if (chunk.Usage >= minUsage) return true;
+
+            Remove(chunk);
+            // Move the ByteBufChunk down the ByteBufChunkList linked-list.
+            return MoveInternal(chunk);
+        }
+
+        private bool Move(ByteBufChunk chunk)
+        {
+            if (chunk.Usage < minUsage)
+            {
+                // Move the ByteBufChunk down the ByteBufChunkList linked-list
+                return MoveInternal(chunk);
+            }
+
+            // ByteBufChunk fits into this ByteBufChunkList, adding it here.
+            AddInternal(chunk);
+            return true;
+        }
+
+        /// <summary>
+        /// Adds the ByteBufChunk to this ByteBufChunkList
+        /// </summary>
+        private void AddInternal(ByteBufChunk chunk)
+        {
+            chunk.Parent = this;
+            if (head == null)
+            {
+                head = chunk;
+                chunk.Prev = null;
+                chunk.Next = null;
+            }
+            else
+            {
+                chunk.Prev = null;
+                chunk.Next = head;
+                head.Prev = chunk;
+                head = chunk;
+            }
+        }
+
+        /// <summary>
+        /// Moves the ByteBufChunk down the ByteBufChunkList linked-list so it will end up in the right
+        /// ByteBufChunkList that has the correct minUsage/maxUsage in respect to ByteBufChunk.Usage.
+        /// </summary>
+        private bool MoveInternal(ByteBufChunk chunk)
+        {
+            if (PrevList == null)
+            {
+                // If there is no previous ByteBufChunkList so return false which result in
+                // having the ByteBufChunk destroyed and memory associated with the ByteBufChunk
+                // will be released.
+                Debug.Assert(chunk.Usage == 0);
+                return false;
+            }
+            
+            return PrevList.Move(chunk);
+        }
+
+        /// <summary>
+        /// Remove the ByteBufChunk from this ByteBufChunkList
+        /// </summary>
+        private void Remove(ByteBufChunk chunk)
+        {
+            Debug.Assert(chunk != null);
+            if (chunk == head)
+            {
+                head = chunk.Next;
+                if (head != null)
+                {
+                    head.Prev = null;
+                }
+            }
+            else
+            {
+                var next = chunk.Next;
+                chunk.Prev.Next = next;
+                if (next != null)
+                {
+                    next.Prev = chunk.Prev;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns a readable string for this ByteBufChunkList
+        /// </summary>
+        public override string ToString()
+        {
+            if (head == null)
+            {
+                return "none";
+            }
+
+            var buf = new StringBuilder();
+            for (var cur = head; ;)
+            {
+                buf.Append(cur);
+                cur = cur.Next;
+                if (cur == null)
+                {
+                    break;
+                }
+                buf.Append(Environment.NewLine);
+            }
+
+            return buf.ToString();
+        }
+    }
+}

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Network/ByteBufPool.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Network/ByteBufPool.cs
@@ -1,0 +1,237 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Microsoft.Spark.CSharp.Services;
+
+namespace Microsoft.Spark.CSharp.Network
+{
+    /// <summary>
+    /// ByteBufPool class is used to manage the ByteBuf pool that allocate and free pooled memory buffer.
+    /// We borrows some ideas from Netty buffer memory management.
+    /// </summary>
+    internal sealed class ByteBufPool
+    {
+        /// <summary>
+        /// The chunk size is calculated with given segment size and chunk order.
+        /// The MaxChunkSize ensure ByteBuf chunk Size (Int32.MaxValue) does not overflow.
+        /// </summary>
+        private const int MaxChunkSize = (int)((int.MaxValue + 1L) / 2);
+
+        private static readonly Lazy<ByteBufPool> DefaultPool =
+            new Lazy<ByteBufPool>(() => new ByteBufPool(DefaultSegmentSize, DefaultChunkOrder, false));
+        private static readonly Lazy<ByteBufPool> DefaultUnsafePool =
+            new Lazy<ByteBufPool>(() => new ByteBufPool(DefaultSegmentSize, DefaultChunkOrder, true));
+
+        private readonly ILoggerService logger = LoggerServiceFactory.GetLogger(typeof(RioSocketWrapper));
+        private readonly bool isUnsafe;
+        private readonly ByteBufChunkList qInit, q000, q025, q050, q075, q100;
+
+        /// <summary>
+        /// The default segment size to delimit a byte array chunk. 
+        /// </summary>
+        public const int DefaultSegmentSize = 131072; // 65536; // 64K
+
+        /// <summary>
+        /// The default chunk order used to calculate chunk size and ensure it is a multiple of a segment size.
+        /// </summary>
+        public const int DefaultChunkOrder = 7; // 65536 << 8 = 16 MBytes per chunk
+
+        /// <summary>
+        /// Initializes a new ByteBufPool instance with a given segment size and chunk order.
+        /// If isUnsafe is true, all memory will be allocated from process's heap by using
+        /// native HeapAlloc API.
+        /// </summary>
+        /// <param name="segmentSize">The size of a segment</param>
+        /// <param name="chunkOrder">Used to caculate chunk size and ensures it is a multiple of a segment size</param>
+        /// <param name="isUnsafe">Indicates whether allocates memory from process's heap</param>
+        public ByteBufPool(int segmentSize, int chunkOrder, bool isUnsafe)
+        {
+            SegmentSize = segmentSize;
+            ChunkSize = ValidateAndCalculateChunkSize(segmentSize, chunkOrder);
+            this.isUnsafe = isUnsafe;
+
+            q100 = new ByteBufChunkList(null, 100, int.MaxValue); // No maxUsage for this list. All 100% usage of chunks will be in here.
+            q075 = new ByteBufChunkList(q100, 75, 100);
+            q050 = new ByteBufChunkList(q075, 50, 100);
+            q025 = new ByteBufChunkList(q050, 25, 75);
+            q000 = new ByteBufChunkList(q025, 1, 50);
+            qInit = new ByteBufChunkList(q000, int.MinValue, 25); // No minUsage for this list. All new chunks will be inserted to here.
+
+            q100.PrevList = q075;
+            q075.PrevList = q050;
+            q050.PrevList = q025;
+            q025.PrevList = q000;
+            q000.PrevList = null;
+            qInit.PrevList = qInit;
+        }
+
+        /// <summary>
+        /// Gets the default byte buffer pool instance for managed memory.
+        /// </summary>
+        /// <remarks>
+        /// You should only be using this instance to allocate/deallocate the managed memory arena
+        /// if you don't want to manage memory arena on your own.
+        /// </remarks>
+        public static ByteBufPool Default
+        {
+            get { return DefaultPool.Value; }
+        }
+
+        /// <summary>
+        /// Gets the default byte arena instance for unmanaged memory.
+        /// </summary>
+        /// <remarks>
+        /// You should only be using this instance to allocate/deallocate the unmanaged memory arena
+        /// if you don't want to manage memory arena on your own.
+        /// </remarks>
+        public static ByteBufPool UnsafeDefault
+        {
+            get { return DefaultUnsafePool.Value; }
+        }
+
+        /// <summary>
+        /// Returns the size of a ByteBuf in this ByteBufPool
+        /// </summary>
+        public int SegmentSize { get; private set; }
+
+        /// <summary>
+        /// Returns the size of a ByteChunk in this ByteBufPool
+        /// </summary>
+        public int ChunkSize { get; private set; }
+
+        /// <summary>
+        /// Allocates a ByteBuf from this ByteBufPool to use.
+        /// </summary>
+        /// <returns>A ByteBuf contained in this ByteBufPool</returns>
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public ByteBuf Allocate()
+        {
+            ByteBuf byteBuf;
+            if (q050.Allocate(out byteBuf) || q025.Allocate(out byteBuf) ||
+                q000.Allocate(out byteBuf) || qInit.Allocate(out byteBuf) ||
+                q075.Allocate(out byteBuf))
+            {
+                return byteBuf;
+            }
+
+            // Add a new chunk and allocate a segment from it.
+            var chunk = ByteBufChunk.NewChunk(this, SegmentSize, ChunkSize, isUnsafe);
+            if (!chunk.Allocate(out byteBuf))
+            {
+                logger.LogError("Failed to allocate a ByteBuf from a new ByteBufChunk. {0}", chunk);
+                return null;
+            }
+            qInit.Add(chunk);
+            return byteBuf;
+        }
+
+        /// <summary>
+        /// Deallocates a ByteBuf back to this ByteBufPool.
+        /// </summary>
+        /// <param name="byteBuf">The ByteBuf to be release.</param>
+        public void Free(ByteBuf byteBuf)
+        {
+            if (byteBuf.ByteBufChunk == null || byteBuf.Capacity == 0 || byteBuf.ByteBufChunk.Size < byteBuf.Offset + byteBuf.Capacity)
+            {
+                throw new Exception("Attempt to free invalid byteBuf");
+            }
+
+            if (byteBuf.Capacity != SegmentSize)
+            {
+                throw new ArgumentException("Segment was not from the same byte arena", "byteBuf");
+            }
+
+            bool mustDestroyChunk;
+            var chunk = byteBuf.ByteBufChunk;
+            lock (this)
+            {
+                mustDestroyChunk = !chunk.Parent.Free(chunk, byteBuf);
+            }
+
+            if (!mustDestroyChunk) return;
+
+            // Destroy chunk not need to be called while holding the synchronized lock.
+            chunk.Parent = null;
+            chunk.Dispose();
+        }
+
+        /// <summary>
+        /// Gets a readable string for this ByteBufPool
+        /// </summary>
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public override string ToString()
+        {
+            StringBuilder buf = new StringBuilder()
+                .Append("Chunk(s) at 0~25%:")
+                .Append(Environment.NewLine)
+                .Append(qInit)
+                .Append(Environment.NewLine)
+                .Append("Chunk(s) at 0~50%:")
+                .Append(Environment.NewLine)
+                .Append(q000)
+                .Append(Environment.NewLine)
+                .Append("Chunk(s) at 25~75%:")
+                .Append(Environment.NewLine)
+                .Append(q025)
+                .Append(Environment.NewLine)
+                .Append("Chunk(s) at 50~100%:")
+                .Append(Environment.NewLine)
+                .Append(q050)
+                .Append(Environment.NewLine)
+                .Append("Chunk(s) at 75~100%:")
+                .Append(Environment.NewLine)
+                .Append(q075)
+                .Append(Environment.NewLine)
+                .Append("Chunk(s) at 100%:")
+                .Append(Environment.NewLine)
+                .Append(q100)
+                .Append(Environment.NewLine);
+
+            return buf.ToString();
+        }
+
+        /// <summary>
+        /// Returns the chunk numbers in each queue.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public int[] GetUsages()
+        {
+            var qUsage = new int[6];
+            var qIndex = 0;
+            for (var q = qInit; q != null; q = q.NextList, qIndex++)
+            {
+                int count = 0;
+                for (var cur = q.head; cur != null; cur = cur.Next, count++) {}
+                qUsage[qIndex] = count;
+            }
+            return qUsage;
+        }
+
+        private static int ValidateAndCalculateChunkSize(int segmentSize, int chunkOrder)
+        {
+            if (chunkOrder > 14)
+            {
+                throw new ArgumentException(string.Format(
+                    "chunkOrder: {0} (expected: 0-14)", chunkOrder));
+            }
+
+            // Ensure the resulting chunkSize does not overflow.
+            var chunkSize = segmentSize;
+            for (var i = chunkOrder; i > 0; i--)
+            {
+                if (chunkSize > MaxChunkSize >> 1)
+                {
+                    throw new ArgumentException(string.Format(
+                        "segmentSize ({0}) << chunkOrder ({1}) must not exceed {2}", segmentSize, chunkOrder, MaxChunkSize));
+                }
+                chunkSize <<= 1;
+            }
+
+            return chunkSize;
+        }
+    }
+}

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Network/DefaultSocketWrapper.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Network/DefaultSocketWrapper.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Spark.CSharp.Network
     /// <summary>
     /// A simple wrapper of System.Net.Sockets.Socket class.
     /// </summary>
-    public class DefaultSocketWrapper : ISocketWrapper
+    internal class DefaultSocketWrapper : ISocketWrapper
     {
         private readonly Socket innerSocket;
 
@@ -83,9 +83,31 @@ namespace Microsoft.Spark.CSharp.Network
         /// Starts listening for incoming connections requests
         /// </summary>
         /// <param name="backlog">The maximum length of the pending connections queue. </param>
-        public void Listen(int backlog = (int)SocketOptionName.MaxConnections)
+        public void Listen(int backlog = 16)
         {
             innerSocket.Listen(backlog);
+        }
+
+        /// <summary>
+        /// Receives network data from this socket, and returns a ByteBuf that contains the received data.
+        /// 
+        /// The DefaultSocketWrapper does not support this function.
+        /// </summary>
+        /// <returns>A ByteBuf object that contains received data.</returns>
+        public ByteBuf Receive()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Sends data to this socket with a ByteBuf object that contains data to be sent.
+        /// 
+        /// The DefaultSocketWrapper does not support this function.
+        /// </summary>
+        /// <param name="data">A ByteBuf object that contains data to be sent</param>
+        public void Send(ByteBuf data)
+        {
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -117,14 +139,18 @@ namespace Microsoft.Spark.CSharp.Network
         }
 
         /// <summary>
+        /// Indicates whether there are data that has been received from the network and is available to be read.
+        /// </summary>
+        public bool HasData { get { return innerSocket.Available > 0; } }
+
+        /// <summary>
         /// Returns the local endpoint.
         /// </summary>
-        public EndPoint LocalEndPoint
-        {
-            get
-            {
-                return innerSocket.LocalEndPoint;
-            }
-        }
+        public EndPoint LocalEndPoint { get { return innerSocket.LocalEndPoint; } }
+
+        /// <summary>
+        /// Returns the remote endpoint if it has one.
+        /// </summary>
+        public EndPoint RemoteEndPoint { get { return innerSocket.RemoteEndPoint; } }
     }
 }

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Network/ISocketWrapper.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Network/ISocketWrapper.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Net;
-using System.Net.Sockets;
 
 namespace Microsoft.Spark.CSharp.Network
 {
@@ -12,7 +11,7 @@ namespace Microsoft.Spark.CSharp.Network
     /// ISocketWrapper interface defines the common methods to operate a socket (traditional socket or 
     /// Windows Registered IO socket)
     /// </summary>
-    public interface ISocketWrapper : IDisposable
+    internal interface ISocketWrapper : IDisposable
     {
         /// <summary>
         /// Accepts a incoming connection request.
@@ -42,11 +41,33 @@ namespace Microsoft.Spark.CSharp.Network
         /// Starts listening for incoming connections requests
         /// </summary>
         /// <param name="backlog">The maximum length of the pending connections queue. </param>
-        void Listen(int backlog = (int)SocketOptionName.MaxConnections);
+        void Listen(int backlog = 16);
+
+        /// <summary>
+        /// Receives network data from this socket, and returns a ByteBuf that contains the received data.
+        /// </summary>
+        /// <returns>A ByteBuf object that contains received data.</returns>
+        ByteBuf Receive();
+
+        /// <summary>
+        /// Sends data to this socket with a ByteBuf object that contains data to be sent.
+        /// </summary>
+        /// <param name="data">A ByteBuf object that contains data to be sent</param>
+        void Send(ByteBuf data);
+
+        /// <summary>
+        /// Indicates whether there are data that has been received from the network and is available to be read.
+        /// </summary>
+        bool HasData { get ; }
 
         /// <summary>
         /// Returns the local endpoint.
         /// </summary>
         EndPoint LocalEndPoint { get; }
+
+        /// <summary>
+        /// Returns the remote endpoint
+        /// </summary>
+        EndPoint RemoteEndPoint { get; }
     }
 }

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Network/RioNative.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Network/RioNative.cs
@@ -1,0 +1,340 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Threading;
+using Microsoft.Spark.CSharp.Services;
+
+namespace Microsoft.Spark.CSharp.Network
+{
+    /// <summary>
+    /// RioNative class imports and initializes RIOSock.dll for use with RIO socket APIs.
+    /// It also provided a simple thread pool that retrieves the results from IO completion port.
+    /// </summary>
+    internal class RioNative : IDisposable
+    {
+        private const int DefaultResultSize = 32; // Default RIO result size that be used to dequeue RIO results from IOCP
+        private static readonly Lazy<RioNative> Default = new Lazy<RioNative>(() => new RioNative());
+        private static readonly ILoggerService Logger = LoggerServiceFactory.GetLogger(typeof(RioNative));
+        private static bool useThreadPool;
+
+        private readonly ConcurrentDictionary<long, RioSocketWrapper> connectedSocks =
+            new ConcurrentDictionary<long, RioSocketWrapper>();
+        private volatile bool keepRunning = true;
+        private bool disposed;
+        private Thread[] workThreadPool;
+
+        private RioNative()
+        {
+            Init();
+        }
+
+        /// <summary>
+        /// Finalizer
+        /// </summary>
+        ~RioNative()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Release all resources.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        internal static int GetWorkThreadNumber()
+        {
+            return Default.Value.workThreadPool.Length;
+        }
+
+        /// <summary>
+        /// Sets whether use thread pool to query RIO socket results, 
+        /// it must be called before calling EnsureRioLoaded()
+        /// </summary>
+        internal static void SetUseThreadPool(bool toUseThreadPool)
+        {
+            useThreadPool = toUseThreadPool;
+        }
+
+        /// <summary>
+        /// Gets the connection table that contains all connections.
+        /// </summary>
+        internal static ConcurrentDictionary<long, RioSocketWrapper> ConnectionTable
+        {
+            get { return Default.Value.connectedSocks; }
+        }
+
+        /// <summary>
+        /// Ensures that the native dll of RIO socket is loaded and initialized.
+        /// </summary>
+        internal static void EnsureRioLoaded()
+        {
+            if (Default.Value == null)
+            {
+                throw new Exception("Failed to load RIOSOCK.dll and initialize it.");
+            }
+
+            if (Default.Value.disposed)
+            {
+                Default.Value.Init();
+            }
+        }
+
+        /// <summary>
+        /// Explicitly unload the native dll of RIO socket, and release resources.
+        /// </summary>
+        internal static void UnloadRio()
+        {
+            if (!Default.IsValueCreated) return;
+            Default.Value.Dispose(false);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (disposed) return;
+
+            keepRunning = false;
+            RIOSockUninitialize();
+            disposed = true;
+
+            if (disposing)
+            {
+                GC.SuppressFinalize(this);
+            }
+            Logger.LogDebug("Disposed RioNative instance.");
+        }
+
+        /// <summary>
+        /// Initializes RIOSock native library.
+        /// </summary>
+        private void Init()
+        {
+            // Initializes the RIOSock
+            var lastError = RIOSockInitialize();
+            if (lastError < 0)
+            {
+                Logger.LogError("RIOSockInitialize() failed with error {0}.", lastError);
+                Marshal.ThrowExceptionForHR(lastError);
+            }
+
+            // Create a thread pool for RIO socket
+            var maxThreads = 1;
+            if (useThreadPool)
+            {
+                maxThreads = Environment.ProcessorCount;
+            }
+
+            workThreadPool = new Thread[maxThreads];
+            for (var i = 0; i < workThreadPool.Length; i++)
+            {
+                var worker = new Thread(WorkThreadFunc)
+                {
+                    Name = "RIOThread " + i,
+                    IsBackground = true
+                };
+
+                workThreadPool[i] = worker;
+                worker.Start();
+            }
+
+            // if everything succeeds, post a Notify to catch the first set of IO
+            var registered = RegisterRIONotify();
+            if (!registered)
+            {
+                // Failed to post a NOTIFY.
+                var socketException = new SocketException();
+                Logger.LogError("RegisterRIONotify() failed with error {0}.", socketException.ErrorCode);
+
+                // Stop threads and clean up resources.
+                keepRunning = false;
+                RIOSockUninitialize();
+                throw socketException;
+            }
+
+            disposed = false;
+        }
+
+        private unsafe void WorkThreadFunc()
+        {
+            RioResult* results = stackalloc RioResult[DefaultResultSize];
+
+            while (keepRunning)
+            {
+                if (!GetRIOCompletionStatus())
+                {
+                    var socketException = new SocketException();
+                    Logger.LogError("GetRIOCompletionStatus() with error {0}. Error Message: {1}",
+                        socketException.ErrorCode, socketException.Message);
+                    //this one is not normal error. might need to debug this issue.
+                    continue;
+                }
+
+                var resultCount = DequeueRIOResults((IntPtr)results, DefaultResultSize);
+                if (resultCount == 0 || resultCount == 0xFFFFFFFF /*RIO_CORRUPT_CQ*/)
+                {
+                    // We were notified there were completions, but we can't dequeue any IO
+                    // Something has gone horribly wrong - likely our CQ is corrupt.
+                    Logger.LogError(
+                        "DequeueRIOResults() returned [{0}] : expected to have dequeued IO after being signaled",
+                        resultCount);
+                    continue;
+                }
+
+                for (uint i = 0; i < resultCount; ++i)
+                {
+                    var result = results[i];
+
+                    RioSocketWrapper socket;
+                    if (connectedSocks.TryGetValue(result.ConnectionId, out socket))
+                    {
+                        socket.IoCompleted(result.RequestId, result.Status, result.BytesTransferred);
+                    }
+                    else
+                    {
+                        if (result.Status == 0 && result.BytesTransferred == 0)
+                        {
+                            // Already normally removed from SocketTable.
+                            break;
+                        }
+
+                        if (result.Status == (int)SocketError.ConnectionAborted)
+                        {
+                            Logger.LogDebug(
+                                "The correlated socket [{0}] already disposed and removed from SocketTable.",
+                                result.ConnectionId);
+                            break;
+                        }
+
+                        var socketException = new SocketException(result.Status);
+                        Logger.LogError("Failed to lookup socket [{0}] from SocketTable with status [{1}] and BytesTransferred [{2}] - Error Message: {3}.",
+                            result.ConnectionId, result.Status, result.BytesTransferred, socketException.Message);
+                    }
+                }
+            }
+        }
+
+        #region PInvoke
+
+        private const string RioSockDll = "RIOSock.dll";
+        private const string Ws2Dll = "WS2_32.dll";
+
+        //
+        // Private functions
+        //
+
+        [DllImport(RioSockDll, CharSet = CharSet.Unicode, SetLastError = true)]
+        [SuppressUnmanagedCodeSecurity]
+        private static extern int RIOSockInitialize();
+
+        [DllImport(RioSockDll, CharSet = CharSet.Unicode, SetLastError = true)]
+        [SuppressUnmanagedCodeSecurity]
+        private static extern void RIOSockUninitialize();
+
+        [DllImport(RioSockDll, CharSet = CharSet.Unicode, SetLastError = true)]
+        [SuppressUnmanagedCodeSecurity]
+        private static extern bool RegisterRIONotify();
+
+        [DllImport(RioSockDll, CharSet = CharSet.Unicode, SetLastError = true)]
+        [SuppressUnmanagedCodeSecurity]
+        private static extern bool GetRIOCompletionStatus();
+
+        [DllImport(RioSockDll, CharSet = CharSet.Unicode, SetLastError = true)]
+        [SuppressUnmanagedCodeSecurity]
+        private static extern uint DequeueRIOResults([Out] IntPtr rioResults, [In] uint rioResultSize);
+
+        //
+        // Internal functions
+        //
+
+        [DllImport(RioSockDll, CharSet = CharSet.Unicode, SetLastError = true)]
+        [SuppressUnmanagedCodeSecurity]
+        internal static extern IntPtr CreateRIOSocket([In, Out] IntPtr localAddr, [In, Out] ref int addrLen);
+
+        [DllImport(RioSockDll, CharSet = CharSet.Unicode, SetLastError = true)]
+        [SuppressUnmanagedCodeSecurity]
+        internal static extern IntPtr CreateRIORequestQueue(
+            [In] IntPtr socket,
+            [In] uint maxOutstandingReceive,
+            [In] uint maxOutstandingSend,
+            [In] long socketCorrelation);
+
+        [DllImport(RioSockDll, CharSet = CharSet.Unicode, SetLastError = true)]
+        [SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe bool PostRIOReceive(
+            [In] IntPtr socketQueue,
+            [In] RioBuf* pData,
+            [In] uint dataBufferCount,
+            [In] uint flags,
+            [In] long requestCorrelation);
+
+        [DllImport(RioSockDll, CharSet = CharSet.Unicode, SetLastError = true)]
+        [SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe bool PostRIOSend(
+            [In] IntPtr socketQueue,
+            [In] RioBuf* pData,
+            [In] uint dataBufferCount,
+            [In] uint flags,
+            [In] long requestCorrelation);
+
+        [DllImport(RioSockDll, CharSet = CharSet.Unicode, SetLastError = true)]
+        [SuppressUnmanagedCodeSecurity]
+        internal static extern bool AllocateRIOCompletion([In] uint numCompletions);
+
+        [DllImport(RioSockDll, CharSet = CharSet.Unicode, SetLastError = true)]
+        [SuppressUnmanagedCodeSecurity]
+        internal static extern bool ReleaseRIOCompletion([In] uint numCompletion);
+
+        [DllImport(RioSockDll, CharSet = CharSet.Unicode, SetLastError = true)]
+        [SuppressUnmanagedCodeSecurity]
+        internal static extern bool ResizeRIORequestQueue(
+            [In] IntPtr rq,
+            [In] uint maxOutstandingReceive,
+            [In] uint maxOutstandingSend);
+
+
+        [DllImport(RioSockDll, CharSet = CharSet.Unicode, SetLastError = true)]
+        [SuppressUnmanagedCodeSecurity]
+        internal static extern IntPtr RegisterRIOBuffer([In] IntPtr dataBuffer, [In] uint dataLength);
+
+        [DllImport(RioSockDll, CharSet = CharSet.Unicode, SetLastError = true)]
+        [SuppressUnmanagedCodeSecurity]
+        internal static extern void DeregisterRIOBuffer([In] IntPtr bufferId);
+
+        [DllImport(Ws2Dll, SetLastError = true)]
+        [SuppressUnmanagedCodeSecurity]
+        internal static extern IntPtr accept([In] IntPtr s, [In, Out] IntPtr addr, [In, Out] ref int addrlen);
+
+        [DllImport(Ws2Dll, SetLastError = true)]
+        [SuppressUnmanagedCodeSecurity]
+        internal static extern int connect([In] IntPtr s, [In] byte[] addr, [In] int addrlen);
+
+        [DllImport(Ws2Dll, SetLastError = true)]
+        [SuppressUnmanagedCodeSecurity]
+        internal static extern int closesocket([In] IntPtr s);
+
+        [DllImport(Ws2Dll, SetLastError = true)]
+        [SuppressUnmanagedCodeSecurity]
+        internal static extern int listen([In] IntPtr s, [In] int backlog);
+
+        #endregion
+    }
+
+    /// <summary>
+    /// The RioResult structure contains data used to indicate request completion results used with RIO socket
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct RioResult
+    {
+        public int Status;
+        public uint BytesTransferred;
+        public long ConnectionId;
+        public long RequestId;
+    }
+}

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Network/RioSocketWrapper.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Network/RioSocketWrapper.cs
@@ -1,0 +1,651 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Microsoft.Spark.CSharp.Services;
+
+namespace Microsoft.Spark.CSharp.Network
+{
+    /// <summary>
+    /// RioSocketWrapper class is a wrapper of a socket that use Windows RIO socket with IO
+    /// completion ports to implement socket operations.
+    /// </summary>
+    internal class RioSocketWrapper : ISocketWrapper
+    {
+        private const int Ipv4AddressSize = 16; // Default buffer size for IP v4 address
+        private const int MaxDataCacheSize = 4096; // The max size of data caching in the queue.
+        private static readonly int InitialCqRoom = 2 * rioRqGrowthFactor; // initial room allocated from completion queue.
+        internal static int rioRqGrowthFactor = 2; // Growth factor used to grow the RIO request queue.
+
+        private readonly ILoggerService logger = LoggerServiceFactory.GetLogger(typeof(RioSocketWrapper));
+        private readonly BlockingCollection<ByteBuf> receivedDataQueue = 
+            new BlockingCollection<ByteBuf>(new ConcurrentQueue<ByteBuf>(), MaxDataCacheSize);
+        private readonly ConcurrentDictionary<long, RequestContext> requestContexts = 
+            new ConcurrentDictionary<long, RequestContext>();
+        private readonly BlockingCollection<int> sendStatusQueue =
+            new BlockingCollection<int>(new ConcurrentQueue<int>(), MaxDataCacheSize);
+
+        private long connectionId;
+        private bool isCleanedUp;
+        private bool isConnected;
+        private bool isListening;
+        private IntPtr rioRqHandle;
+        private uint rqReservedSize = 2 * (uint)rioRqGrowthFactor;
+        private uint rqUsed;
+
+        /// <summary>
+        /// Default ctor that creates a new instance of RioSocketWrapper class.
+        /// The instance binds to loop-back address with port 0.
+        /// </summary>
+        public unsafe RioSocketWrapper()
+        {
+            RioNative.EnsureRioLoaded();
+
+            // Creates a socket handle by calling native method.
+            var sockaddlen = Ipv4AddressSize;
+            var addrbuf = stackalloc byte[(sockaddlen / IntPtr.Size + 2) * IntPtr.Size];
+            var sockaddr = (IntPtr)addrbuf;
+            SockHandle = RioNative.CreateRIOSocket(sockaddr, ref sockaddlen);
+            if (SockHandle == new IntPtr(-1))
+            {
+                // if the native call fails we'll throw a SocketException
+                var socketException = new SocketException();
+                logger.LogError("Native CreateRIOSocket() failed with error {0}", socketException.ErrorCode);
+                throw socketException;
+            }
+
+            // Generate the local IP endpoint from the returned raw socket address data.
+            LocalEndPoint = CreateIpEndPoint(sockaddr);
+        }
+
+        /// <summary>
+        /// Initializes a RioSocketWrapper instance for an accepted socket.
+        /// </summary>
+        private RioSocketWrapper(IntPtr socketHandle, EndPoint localEp, EndPoint remoteEp)
+        {
+            SockHandle = socketHandle;
+            LocalEndPoint = localEp;
+            RemoteEndPoint = remoteEp;
+            CreateRequestQueue();
+            isConnected = true;
+            // Post a receive operation from the connected RIO socket.
+            DoReceive();
+        }
+
+        /// <summary>
+        /// Finalizer
+        /// </summary>
+        ~RioSocketWrapper()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Indicates whether there are data that has been received from the network and is available to be read.
+        /// </summary>
+        public bool HasData { get { return receivedDataQueue.Count > 0; } }
+
+        /// <summary>
+        /// Returns the local endpoint.
+        /// </summary>
+        public EndPoint LocalEndPoint { get; private set; }
+
+        /// <summary>
+        /// Returns the remote endpoint
+        /// </summary>
+        public EndPoint RemoteEndPoint { get; private set; }
+
+        /// <summary>
+        /// Returns the handle of native socket.
+        /// </summary>
+        internal IntPtr SockHandle { get; private set; }
+
+        /// <summary>
+        /// Accepts a incoming connection request.
+        /// </summary>
+        /// <returns>A ISocket instance used to send and receive data</returns>
+        public unsafe ISocketWrapper Accept()
+        {
+            EnsureAccessible();
+            if (!isListening)
+            {
+                throw new InvalidOperationException("You must call the Listen method before performing this operation.");
+            }
+
+            var sockaddrlen = Ipv4AddressSize;
+            var addrbuf = stackalloc byte[(sockaddrlen / IntPtr.Size + 2) * IntPtr.Size]; //sizeof DWORD
+            var sockaddr = (IntPtr)addrbuf;
+
+            var acceptedSockHandle = RioNative.accept(SockHandle, sockaddr, ref sockaddrlen);
+            if (acceptedSockHandle == new IntPtr(-1))
+            {
+                // if the native call fails we'll throw a SocketException
+                var socketException = new SocketException();
+                logger.LogError("Native accept() failed with error {0}", socketException.NativeErrorCode);
+                throw socketException;
+            }
+
+            var remoteEp = CreateIpEndPoint(sockaddr);
+            var socket = new RioSocketWrapper(acceptedSockHandle, LocalEndPoint, remoteEp);
+            logger.LogDebug("Accepted connection from {0} to {1}", socket.RemoteEndPoint, socket.LocalEndPoint);
+            return socket;
+        }
+
+        /// <summary>
+        /// Close the ISocket connections and releases all associated resources.
+        /// </summary>
+        public void Close()
+        {
+            Dispose(true);
+        }
+
+        /// <summary>
+        /// Establishes a connection to a remote host that is specified by an IP address and a port number
+        /// </summary>
+        /// <param name="remoteaddr">The IP address of the remote host</param>
+        /// <param name="port">The port number of the remote host</param>
+        public void Connect(IPAddress remoteaddr, int port)
+        {
+            EnsureAccessible();
+
+            var remoteEp = new IPEndPoint(remoteaddr, port);
+            int sockaddrlen;
+            var sockaddr = GetNativeSocketAddress(remoteEp, out sockaddrlen);
+            var errorCode = RioNative.connect(SockHandle, sockaddr, sockaddrlen);
+            if (errorCode != 0)
+            {
+                // if the native call fails we'll throw a SocketException
+                var socketException = new SocketException();
+                logger.LogError("Native connect() failed with error {0}", socketException.ErrorCode);
+                throw socketException;
+            }
+
+            CreateRequestQueue();
+            isConnected = true;
+            RemoteEndPoint = remoteEp;
+
+            // Post a receive operation from the connected RIO socket.
+            DoReceive();
+        }
+
+        /// <summary>
+        /// Releases all resources used by the current instance of the RioSocketWrapper class.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        /// <summary>
+        /// Returns a stream used to send and receive data.
+        /// </summary>
+        /// <returns>The underlying Stream instance that be used to send and receive data</returns>
+        public Stream GetStream()
+        {
+            EnsureAccessible();
+            if (!isConnected)
+            {
+                throw new InvalidOperationException("The operation is not allowed on non-connected sockets.");
+            }
+            return new SocketStream(this);
+        }
+
+        /// <summary>
+        /// Starts listening for incoming connections requests
+        /// </summary>
+        /// <param name="backlog">The maximum length of the pending connections queue. </param>
+        public void Listen(int backlog = 16)
+        {
+            EnsureAccessible();
+            if (isListening) return;
+
+            var errorCode = RioNative.listen(SockHandle, backlog);
+            if (errorCode != 0)
+            {
+                var socketException = new SocketException();
+                logger.LogError("Native listen() failed with error {0}", socketException.ErrorCode);
+                throw socketException;
+            }
+            isListening = true;
+        }
+
+        /// <summary>
+        /// Receives network data from this socket, and returns a ByteBuf that contains the received data.
+        /// </summary>
+        /// <returns>A ByteBuf object that contains received data.</returns>
+        public ByteBuf Receive()
+        {
+            EnsureAccessible();
+            if (!isConnected)
+            {
+                throw new InvalidOperationException("The operation is not allowed on non-connected sockets.");
+            }
+
+            var data = receivedDataQueue.Take();
+            if (data.Status == (int) SocketError.Success) return data;
+
+            // Throw exception if there is an error.
+            data.Release();
+            Dispose(true);
+            SocketException sockException = new SocketException(data.Status);
+            throw sockException;
+        }
+
+        /// <summary>
+        /// Sends data to this socket with a ByteBuf object that contains data to be sent.
+        /// </summary>
+        /// <param name="data">A ByteBuf object that contains data to be sent</param>
+        public void Send(ByteBuf data)
+        {
+            EnsureAccessible();
+            if (!isConnected)
+            {
+                throw new InvalidOperationException("The operation is not allowed on non-connected sockets.");
+            }
+            if (!data.IsReadable())
+            {
+                throw new ArgumentException("The parameter {0} must contain one or more elements.", "data");
+            }
+
+            var context = new RequestContext(SocketOperation.Send, data);
+            DoSend(GenerateUniqueKey(), context);
+
+            var status = sendStatusQueue.Take();
+            if (status == (int)SocketError.Success) return;
+
+            // throw a SocketException if theres is an error.
+            Dispose(true);
+            var socketException = new SocketException(status);
+            throw socketException;
+        }
+
+        /// <summary>
+        /// IO completion callback
+        /// </summary>
+        internal void IoCompleted(long requestId, int status, uint byteTransferred)
+        {
+            if (isCleanedUp) return;
+            ReleaseRequest();
+
+            RequestContext context;
+            if (!requestContexts.TryRemove(requestId, out context)) return;
+
+            switch (context.Operation)
+            {
+                case SocketOperation.Receive:
+                    ProcessReceive(context, status, byteTransferred);
+                    return;
+
+                case SocketOperation.Send:
+                    ProcessSend(requestId, context, status, byteTransferred);
+                    return;
+                
+                default:
+                    throw new InvalidOperationException("Invalid socket operation - not a receive / send operation.");
+            }
+        }
+
+        /// <summary>
+        /// Allocates a room form request queue for this next IO.
+        /// </summary>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        private int AllocateRequest()
+        {
+            var newRqUsed = rqUsed + 1;
+            if (newRqUsed > rqReservedSize)
+            {
+                var newRqReservedSize = rqReservedSize + rioRqGrowthFactor;
+                if (!RioNative.AllocateRIOCompletion((uint)rioRqGrowthFactor))
+                {
+                    var errorCode = Marshal.GetLastWin32Error();
+                    logger.LogError(
+                        "Failed to allocate completions to this socket. AllocateRIOCompletion() returns error {0}",
+                        errorCode);
+                    return errorCode;
+                }
+
+                // Resize the RQ.
+                if (!RioNative.ResizeRIORequestQueue(rioRqHandle, (uint)newRqReservedSize >> 1, (uint)newRqReservedSize >> 1))
+                {
+                    var errorCode = Marshal.GetLastWin32Error();
+                    logger.LogError("Failed to resize the request queue. ResizeRIORequestQueue() returns error {0}",
+                        errorCode);
+                    RioNative.ReleaseRIOCompletion((uint)rioRqGrowthFactor);
+                    return errorCode;
+                }
+
+                // since it succeeded, update reserved with the new size
+                rqReservedSize = (uint)newRqReservedSize;
+            }
+
+            // everything succeeded - update rqUsed with the new slots being used for this next IO
+            rqUsed = newRqUsed;
+            return 0;
+        }
+
+        /// <summary>
+        /// Creates a request queue for this socket operation
+        /// </summary>
+        private void CreateRequestQueue()
+        {
+            // Allocate completion from completion queue
+            if (!RioNative.AllocateRIOCompletion((uint)InitialCqRoom))
+            {
+                var socketException = new SocketException();
+                logger.LogError(
+                    "AllocateRIOCompletion() failed to allocate completions to this socket. Returns error {0}",
+                    socketException.ErrorCode);
+                throw socketException;
+            }
+
+            // Create the RQ for this socket.
+            connectionId = GenerateUniqueKey();
+            while (!RioNative.ConnectionTable.TryAdd(connectionId, this))
+            {
+                connectionId = GenerateUniqueKey();
+            }
+
+            rioRqHandle = RioNative.CreateRIORequestQueue(SockHandle, rqReservedSize >> 1, rqReservedSize >> 1, connectionId);
+            if (rioRqHandle != IntPtr.Zero) return;
+
+            // Error Handling
+            var sockException = new SocketException();
+            RioNative.ReleaseRIOCompletion((uint)InitialCqRoom);
+            RioSocketWrapper sock;
+            RioNative.ConnectionTable.TryRemove(connectionId, out sock);
+            logger.LogError("CreateRIORequestQueue() returns error {0}", sockException.ErrorCode);
+            throw sockException;
+        }
+
+        private void Dispose(bool disposing)
+        {
+            // Mark this as disposed before changing anything else.
+            var cleanedUp = isCleanedUp;
+            isCleanedUp = true;
+            if (!cleanedUp && disposing)
+            {
+                try
+                {
+                    // Release room back to Completion Queue
+                    RioNative.ReleaseRIOCompletion((uint)InitialCqRoom);
+
+                    // Remove this socket from the connected socket table.
+                    RioSocketWrapper socket;
+                    RioNative.ConnectionTable.TryRemove(connectionId, out socket);
+                }
+                catch (Exception)
+                {
+                    logger.LogDebug("RioNative default instance already disposed.");
+                }
+
+                // Remove all pending socket operations
+                if (!requestContexts.IsEmpty)
+                {
+                    foreach (var keyValuePair in requestContexts)
+                    {
+                        // Release the data buffer of the pending operation
+                        keyValuePair.Value.Data.Release();
+                    }
+                    requestContexts.Clear();
+                }
+
+                // Remove received Data from the queue, and release buffer back to byte pool.
+                while (receivedDataQueue.Count > 0)
+                {
+                    ByteBuf data;
+                    receivedDataQueue.TryTake(out data);
+                    data.Release();
+                }
+
+                // Close the socket handle. No need to release Request Queue handle that
+                // will be gone once the socket handle be closed.
+                if (SockHandle != IntPtr.Zero)
+                {
+                    RioNative.closesocket(SockHandle);
+                    SockHandle = IntPtr.Zero;
+                }
+
+                GC.SuppressFinalize(this);
+            }
+
+            isConnected = false;
+            isListening = false;
+        }
+
+        private void EnsureAccessible()
+        {
+            if (isCleanedUp)
+            {
+                throw new ObjectDisposedException(GetType().FullName);
+            }
+        }
+
+        /// <summary>
+        /// Posts a receive operation to this socket
+        /// </summary>
+        private unsafe void DoReceive()
+        {
+            // Make a room from Request Queue of this socket for operation.
+            var errorStatus = AllocateRequest();
+            if (errorStatus != 0)
+            {
+                logger.LogError("Cannot post receive operation due to no room in Request Queue.");
+                receivedDataQueue.Add(ByteBuf.NewErrorStatusByteBuf(errorStatus));
+                return;
+            }
+
+            // Allocate buffer to receive incoming network data.
+            var dataBuffer = ByteBufPool.UnsafeDefault.Allocate();
+            if (dataBuffer == null)
+            {
+                logger.LogError("Failed to allocate ByteBuf at DoReceive().");
+                receivedDataQueue.Add(ByteBuf.NewErrorStatusByteBuf((int)SocketError.NoBufferSpaceAvailable));
+                return;
+            }
+            var context = new RequestContext(SocketOperation.Receive, dataBuffer);
+            var recvId = GenerateUniqueKey();
+
+            // Add the operation context to request table for completion callback.
+            while (!requestContexts.TryAdd(recvId, context))
+            {
+                // Generate another key, if the key is duplicated.
+                recvId = GenerateUniqueKey();
+            }
+
+            // Post a receive operation via native method.
+            var rioBuf = dataBuffer.GetInputRioBuf();
+            if (RioNative.PostRIOReceive(rioRqHandle, &rioBuf, 1, 0, recvId)) return;
+
+            requestContexts.TryRemove(recvId, out context);
+            context.Data.Release();
+
+            if (isCleanedUp)
+            {
+                logger.LogDebug("Socket is already disposed. DoReceive() do nothing.");
+                receivedDataQueue.Add(ByteBuf.NewErrorStatusByteBuf((int)SocketError.NetworkDown));
+                return;
+            }
+
+            // Log exception, if post receive operation failed.
+            var socketException = new SocketException();
+            logger.LogError("Failed to call DoReceive() with error code [{0}], error message: {1}",
+                socketException.ErrorCode, socketException.Message);
+            context.Data.Status = socketException.ErrorCode;
+            receivedDataQueue.Add(context.Data);
+        }
+
+        /// <summary>
+        /// This method is invoked by the IoCompleted method to process the receive completion.
+        /// </summary>
+        private void ProcessReceive(RequestContext context, int status, uint byteTransferred)
+        {
+            context.Data.Status = status;
+            var data = context.Data;
+            data.WriterIndex += (int)byteTransferred;
+            receivedDataQueue.Add(data);
+
+            if (status != (int) SocketError.Success)
+            {
+                logger.LogError("Socket receive operation failed with error {0}", status);
+                context.Data.Release();
+                return;
+            }
+
+            // Posts another receive operation
+            DoReceive();
+        }
+
+        /// <summary>
+        /// Posts a send operation to this socket.
+        /// </summary>
+        private unsafe void DoSend(long sendId, RequestContext context)
+        {
+            // Make a room from Request Queue of this socket for operation.
+            var errorStatus = AllocateRequest();
+            if ( errorStatus != 0)
+            {
+                logger.LogError("Cannot post send operation due to no room in Request Queue.");
+                sendStatusQueue.Add(errorStatus);
+                return;
+            }
+
+            // Add the operation context to request table for completion callback.
+            while (!requestContexts.TryAdd(sendId, context))
+            {
+                // Generate another key, if the key is duplicated.
+                sendId = GenerateUniqueKey();
+            }
+
+            // Post a send operation via native method.
+            var rioBuf = context.Data.GetOutputRioBuf();
+            if (RioNative.PostRIOSend(rioRqHandle, &rioBuf, 1, 0, sendId)) return;
+
+            requestContexts.TryRemove(sendId, out context);
+            context.Data.Release();
+
+            if (isCleanedUp)
+            {
+                logger.LogDebug("Socket is already disposed. PostSend() do nothing.");
+                receivedDataQueue.Add(ByteBuf.NewErrorStatusByteBuf((int)SocketError.NetworkDown));
+                return;
+            }
+
+            // Log exception, if post send operation failed.
+            var socketException = new SocketException();
+            logger.LogError("Failed to call PostRIOSend() with error code [{0}]. Error message: {1}",
+                socketException.ErrorCode, socketException.Message);
+            sendStatusQueue.Add(socketException.ErrorCode);
+        }
+
+        /// <summary>
+        /// This method is invoked by the IoCompleted method to process the send completion.
+        /// </summary>
+        private void ProcessSend(long requestId, RequestContext context, int status, uint byteTransferred)
+        {
+            sendStatusQueue.Add(status);
+            if (status != (int)SocketError.Success)
+            {
+                logger.LogError("Socket send operation failed with error {0}", status);
+                context.Data.Release();
+                return;
+            }
+
+            var data = context.Data;
+            data.ReaderIndex += (int)byteTransferred;
+            if (data.IsReadable())
+            {
+                // If some of the bytes in the message have NOT been sent,
+                // then we need to post another send operation.
+                context.Data = data;
+                DoSend(requestId, context);
+            }
+            else
+            {
+                // All the bytes in the data have been sent, 
+                // release the buffer back to pool. 
+                data.Release();
+            }
+        }
+
+        /// <summary>
+        /// Release room back to request queue.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        private void ReleaseRequest()
+        {
+            rqUsed -= 1;
+        }
+
+        private static unsafe IPEndPoint CreateIpEndPoint(IntPtr addr)
+        {
+            var addrBuf = (byte*)addr;
+            var address = ((addrBuf[4] & 0x000000FF) |
+                           (addrBuf[5] << 8 & 0x0000FF00) |
+                           (addrBuf[6] << 16 & 0x00FF0000) |
+                           (addrBuf[7] << 24)) & 0x00000000FFFFFFFF;
+
+            var ipAddr = new IPAddress(address);
+            var port = (addrBuf[2] << 8 & 0xFF00) | addrBuf[3];
+            return new IPEndPoint(ipAddr, port);
+        }
+
+        /// <summary>
+        /// Generates a unique key from a GUID.
+        /// </summary>
+        private static long GenerateUniqueKey()
+        {
+            Debug.Assert(IntPtr.Size == 8); // For x64 bits.
+            var buffer = Guid.NewGuid().ToByteArray();
+            return BitConverter.ToInt64(buffer, 0);
+        }
+
+        private static byte[] GetNativeSocketAddress(IPEndPoint ipEp, out int sockaddrLen)
+        {
+            var sockaddr = ipEp.Serialize();
+            sockaddrLen = sockaddr.Size;
+            var addrbuf = new byte[(sockaddrLen / IntPtr.Size + 2) * IntPtr.Size]; //sizeof DWORD
+
+            // Address Family serialization
+            addrbuf[0] = sockaddr[0];
+            addrbuf[1] = sockaddr[1];
+
+            // Port serialization
+            addrbuf[2] = sockaddr[2];
+            addrbuf[3] = sockaddr[3];
+
+            // IPv4 Address serialization
+            addrbuf[4] = sockaddr[4];
+            addrbuf[5] = sockaddr[5];
+            addrbuf[6] = sockaddr[6];
+            addrbuf[7] = sockaddr[7];
+            return addrbuf;
+        }
+    }
+    
+    internal class RequestContext
+    {
+        public RequestContext(SocketOperation operation, ByteBuf data)
+        {
+            Operation = operation;
+            Data = data;
+        }
+
+        public SocketOperation Operation { get; private set; }
+        public ByteBuf Data { get; set; }
+    }
+
+    internal enum SocketOperation
+    {
+        None = 0,
+        Receive,
+        Send
+    }
+}

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Network/SaeaSocketWrapper.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Network/SaeaSocketWrapper.cs
@@ -1,0 +1,462 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.Spark.CSharp.Services;
+
+namespace Microsoft.Spark.CSharp.Network
+{
+    /// <summary>
+    /// SaeaSocketWrapper class is a wrapper of a socket that use SocketAsyncEventArgs class
+    /// to implement socket operations.
+    /// </summary>
+    internal class SaeaSocketWrapper : ISocketWrapper
+    {
+        private const int MaxDataCacheSize = 4096; // The max size of data caching in the queue.
+
+        private readonly ILoggerService logger = LoggerServiceFactory.GetLogger(typeof(SaeaSocketWrapper));
+        private readonly BlockingCollection<ByteBuf> receivedDataQueue =
+            new BlockingCollection<ByteBuf>(new ConcurrentQueue<ByteBuf>(), MaxDataCacheSize);
+        private readonly BlockingCollection<int> sendStatusQueue =
+            new BlockingCollection<int>(new ConcurrentQueue<int>(), MaxDataCacheSize);
+
+        private readonly ConcurrentQueue<SocketAsyncEventArgs> poolOfAcceptEvents =
+            new ConcurrentQueue<SocketAsyncEventArgs>();
+        private readonly ConcurrentQueue<SocketAsyncEventArgs> poolOfRecvSendEvents =
+            new ConcurrentQueue<SocketAsyncEventArgs>(); 
+
+        private readonly SaeaSocketWrapper parent;
+        private Socket innerSocket;
+        private bool isCleanedUp;
+        private bool isConnected;
+
+        /// <summary>
+        /// Default ctor that creates a new instance of SaeaSocketWrapper class.
+        /// The instance binds to loop-back address with port 0.
+        /// </summary>
+        public SaeaSocketWrapper()
+        {
+            innerSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            var localEndPoint = new IPEndPoint(IPAddress.Loopback, 0);
+            innerSocket.Bind(localEndPoint);
+        }
+
+        /// <summary>
+        /// Initializes a SaeaSocketWrapper instance for an accepted socket.
+        /// </summary>
+        private SaeaSocketWrapper(SaeaSocketWrapper parent, Socket acceptedSocket)
+        {
+            this.parent = parent;
+            innerSocket = acceptedSocket;
+            isConnected = true;
+        }
+
+        /// <summary>
+        /// Finalizer.
+        /// </summary>
+        ~SaeaSocketWrapper()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Indicates whether there are data that has been received from the network and is available to be read.
+        /// </summary>
+        public bool HasData
+        {
+            get
+            {
+                EnsureAccessible();
+                return receivedDataQueue.Count > 0;
+            }
+        }
+
+        /// <summary>
+        /// Returns the local endpoint.
+        /// </summary>
+        public EndPoint LocalEndPoint { get { return innerSocket.LocalEndPoint; } }
+
+        /// <summary>
+        /// Returns the remote endpoint
+        /// </summary>
+        public EndPoint RemoteEndPoint { get { return innerSocket.RemoteEndPoint; } }
+
+        /// <summary>
+        /// Accepts a incoming connection request.
+        /// </summary>
+        /// <returns>A ISocket instance used to send and receive data</returns>
+        public ISocketWrapper Accept()
+        {
+            var socket = innerSocket.Accept();
+            var clientSock = new SaeaSocketWrapper(this, socket);
+            logger.LogDebug("Accepted connection from {0} to {1}", clientSock.RemoteEndPoint, clientSock.LocalEndPoint);
+            DoReceive(clientSock);
+            return clientSock;
+        }
+
+        /// <summary>
+        /// Close the ISocket connections and releases all associated resources.
+        /// </summary>
+        public void Close()
+        {
+            Dispose(true);
+        }
+
+        /// <summary>
+        /// Establishes a connection to a remote host that is specified by an IP address and a port number
+        /// </summary>
+        /// <param name="remoteaddr">The IP address of the remote host</param>
+        /// <param name="port">The port number of the remote host</param>
+        public void Connect(IPAddress remoteaddr, int port)
+        {
+            var remoteEndPoint = new IPEndPoint(remoteaddr, port);
+            innerSocket.Connect(remoteEndPoint);
+            isConnected = true;
+
+            DoReceive(this);
+        }
+
+        /// <summary>
+        /// Releases all resources used by the current instance of the SaeaSocketWrapper class.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        /// <summary>
+        /// Returns a stream used to send and receive data.
+        /// </summary>
+        /// <returns>The underlying Stream instance that be used to send and receive data</returns>
+        public Stream GetStream()
+        {
+            EnsureAccessible();
+            if (!isConnected)
+            {
+                throw new InvalidOperationException("The operation is not allowed on non-connected sockets.");
+            }
+
+            return new SocketStream(this);
+        }
+
+        /// <summary>
+        /// Starts listening for incoming connections requests
+        /// </summary>
+        /// <param name="backlog">The maximum length of the pending connections queue. </param>
+        public void Listen(int backlog = 16)
+        {
+            innerSocket.Listen(backlog);
+        }
+
+        /// <summary>
+        /// Receives network data from this socket, and returns a ByteBuf that contains the received data.
+        /// </summary>
+        /// <returns>A ByteBuf object that contains received data.</returns>
+        public ByteBuf Receive()
+        {
+            EnsureAccessible();
+            if (!isConnected)
+            {
+                throw new InvalidOperationException("The operation is not allowed on non-connected sockets.");
+            }
+
+            var data = receivedDataQueue.Take();
+            if (data.Status == (int) SocketError.Success) return data;
+
+            // throw a SocketException if theres is an error.
+            data.Release();
+            Dispose(true);
+            var socketException = new SocketException(data.Status);
+            throw socketException;
+        }
+
+        /// <summary>
+        /// Sends data to this socket with a ByteBuf object that contains data to be sent.
+        /// </summary>
+        /// <param name="data">A ByteBuf object that contains data to be sent</param>
+        public void Send(ByteBuf data)
+        {
+            EnsureAccessible();
+            if (!isConnected)
+            {
+                throw new InvalidOperationException("The operation is not allowed on non-connected sockets.");
+            }
+
+            if (!data.IsReadable())
+            {
+                throw new ArgumentException("The parameter {0} must contain one or more elements.", "data");
+            }
+
+            var dataToken = new SockDataToken(this, data);
+            if (parent != null)
+            {
+                parent.DoSend(dataToken);
+            }
+            else
+            {
+                DoSend(dataToken);
+            }
+            var status = sendStatusQueue.Take();
+            if (status == (int) SocketError.Success) return;
+
+            // throw a SocketException if theres is an error.
+            dataToken.Reset();
+            Dispose(true);
+            var socketException = new SocketException(status);
+            throw socketException;
+        }
+
+        /// <summary>
+        /// Implementation of the Dispose pattern.
+        /// </summary>
+        private void Dispose(bool disposing)
+        {
+            // Mark this as disposed before changing anything else.
+            var cleanedUp = isCleanedUp;
+            isCleanedUp = true;
+            if (cleanedUp || !disposing) return;
+
+            if (innerSocket != null)
+            {
+                try
+                {
+                    // Gracefully shut down socket first.
+                    innerSocket.Shutdown(SocketShutdown.Both);
+                }
+                catch (Exception)
+                {
+                    // Ignore exceptions from Shutdown function
+                }
+                finally
+                {
+                    innerSocket.Dispose();
+                }
+                innerSocket = null;
+            }
+
+            SocketAsyncEventArgs eventArgs;
+            while (poolOfAcceptEvents.Count > 0)
+            {
+                poolOfAcceptEvents.TryDequeue(out eventArgs);
+                eventArgs.Dispose();
+            }
+
+            while (poolOfRecvSendEvents.Count > 0)
+            {
+                poolOfRecvSendEvents.TryDequeue(out eventArgs);
+                if (eventArgs.UserToken != null)
+                {
+                    var dataToken = (SockDataToken) eventArgs.UserToken;
+                    if (dataToken.ClientSocket != null)
+                    {
+                        dataToken.ClientSocket.Dispose();
+                    }
+                    dataToken.Reset();
+                }
+                eventArgs.Dispose();
+            }
+
+            while (receivedDataQueue.Count > 0)
+            {
+                ByteBuf data;
+                receivedDataQueue.TryTake(out data);
+                data.Release();
+            }
+
+            GC.SuppressFinalize(this);
+
+            isCleanedUp = true;
+            isConnected = false;
+        }
+
+        private void EnsureAccessible()
+        {
+            if (isCleanedUp)
+            {
+                throw new ObjectDisposedException(GetType().FullName);
+            }
+        }
+
+        /// <summary>
+        /// The callback is called whenever a receive or send operation completes. However,
+        /// it is not be called if the receive/send operation completes synchronously.
+        /// </summary>
+        private void IoCompleted(object sender, SocketAsyncEventArgs e)
+        {
+            switch (e.LastOperation)
+            {
+                case SocketAsyncOperation.Receive:
+                    ProcessReceive(e);
+                    break;
+
+                case SocketAsyncOperation.Send:
+                    ProcessSend(e);
+                    break;
+
+                default:
+                    throw new ArgumentException(
+                        "The last operation completed on the socket was not a receive or send");
+            }
+        }
+
+        /// <summary>
+        /// Post a receive operation
+        /// </summary>
+        private void DoReceive(SaeaSocketWrapper clientSocket)
+        {
+            // Prepares the SocketAsyncEventArgs for receive operation.
+            SocketAsyncEventArgs recvEventArg;
+            if (!poolOfRecvSendEvents.TryDequeue(out recvEventArg))
+            {
+                recvEventArg = new SocketAsyncEventArgs();
+                recvEventArg.Completed += IoCompleted;
+            }
+            
+            // Allocate buffer for the receive operation.
+            var dataBuf = ByteBufPool.Default.Allocate();
+            recvEventArg.UserToken = new SockDataToken(clientSocket, dataBuf);
+            recvEventArg.SetBuffer(dataBuf.Array, dataBuf.WriterIndexOffset, dataBuf.WritableBytes);
+
+            // Post async receive operation on the socket
+            var socket = clientSocket.innerSocket;
+            recvEventArg.AcceptSocket = socket;
+            if (clientSocket.isCleanedUp || socket == null)
+            {
+                // do nothing if client socket already disposed.
+                dataBuf.Status = (int) SocketError.NetworkDown;
+                dataBuf.Release();
+                recvEventArg.UserToken = null;
+                clientSocket.receivedDataQueue.Add(dataBuf);
+                return;
+            }
+
+            var willRaiseEvent = socket.ReceiveAsync(recvEventArg);
+            if (!willRaiseEvent)
+            {
+                // The operation completed synchronously, we need to call ProcessReceive method directly
+                ProcessReceive(recvEventArg);
+            }
+        }
+
+        /// <summary>
+        /// This method is invoked by the IoCompleted method when an asynchronous receive
+        /// operation completes. If the remote host closed the connection, then the socket
+        /// is closed. Otherwise, we process the received data.
+        /// </summary>
+        private void ProcessReceive(SocketAsyncEventArgs recvEventArg)
+        {
+            var userToken = (SockDataToken) recvEventArg.UserToken;
+            var recvData = userToken.DetachData();
+            var clientSocket = userToken.ClientSocket;
+            //update write index according to the BytesTransferred
+            recvData.WriterIndex += recvEventArg.BytesTransferred;
+            recvData.Status = (int)recvEventArg.SocketError;
+            clientSocket.receivedDataQueue.Add(recvData);
+
+            if (recvEventArg.SocketError != SocketError.Success)
+            {
+                return;
+            }
+
+            // Recycle the EventArgs
+            recvEventArg.UserToken = null;
+            poolOfRecvSendEvents.Enqueue(recvEventArg);
+            
+            // Post another receive operation
+            DoReceive(clientSocket);
+        }
+
+        /// <summary>
+        /// Posts a send operation with a SockDataToken which contains the data to be sent.
+        /// </summary>
+        private void DoSend(SockDataToken dataToken)
+        {
+            // Prepare the SocketAsyncEventArgs for send operation
+            SocketAsyncEventArgs sendEventArg;
+            if (!poolOfRecvSendEvents.TryDequeue(out sendEventArg))
+            {
+                sendEventArg = new SocketAsyncEventArgs();
+                sendEventArg.Completed += IoCompleted;
+            }
+            sendEventArg.UserToken = dataToken;
+            sendEventArg.AcceptSocket = dataToken.ClientSocket.innerSocket;
+            DoSend(sendEventArg);
+        }
+
+        /// <summary>
+        /// Posts a send operation with a send EventArgs
+        /// </summary>
+        private void DoSend(SocketAsyncEventArgs sendEventArg)
+        {
+            // Set buffer for the SocketAsyncEventArgs
+            var dataToken = (SockDataToken)sendEventArg.UserToken;
+            var data = dataToken.Data;
+            sendEventArg.SetBuffer(data.Array, data.ReaderIndexOffset, data.ReadableBytes);
+
+            //post asynchronous send operation
+            var socket = dataToken.ClientSocket.innerSocket;
+            sendEventArg.AcceptSocket = socket;
+            if (dataToken.ClientSocket.isCleanedUp || socket == null)
+            {
+                // do nothing if client socket already disposed.
+                var clientSocket = dataToken.ClientSocket;
+                dataToken.Reset();
+                clientSocket.sendStatusQueue.Add((int)SocketError.NetworkDown);
+                return;
+            }
+
+            var willRaiseEvent = socket.SendAsync(sendEventArg);
+            if (!willRaiseEvent)
+            {
+                // The operation completed synchronously, we need to call ProcessSend method directly
+                ProcessSend(sendEventArg);
+            }
+        }
+
+        /// <summary>
+        /// This method is called by IoCompleted() when an asynchronous send completes.  
+        /// If all of the data has NOT been sent, then it calls PostSend to send more data. 
+        /// </summary>
+        private void ProcessSend(SocketAsyncEventArgs sendEventArg)
+        {
+            var sendToken = (SockDataToken)sendEventArg.UserToken;
+            sendToken.ClientSocket.sendStatusQueue.Add((int)sendEventArg.SocketError);
+            if (sendEventArg.SocketError != SocketError.Success)
+            {
+                sendToken.Reset();
+                sendEventArg.UserToken = null;
+                if (parent != null)
+                {
+                    parent.poolOfRecvSendEvents.Enqueue(sendEventArg);
+                }
+                return;
+            }
+            
+            var data = sendToken.Data;
+            data.ReaderIndex += sendEventArg.BytesTransferred;
+            if (data.IsReadable())
+            {
+                // If some of the bytes in the message have NOT been sent,
+                // then we will need to post another send operation.
+                DoSend(sendEventArg);
+            }
+            else
+            {
+                // All the bytes in the message have been sent. 
+                sendToken.Reset();
+                sendEventArg.UserToken = null;
+                if (parent != null)
+                {
+                    parent.poolOfRecvSendEvents.Enqueue(sendEventArg);
+                    return;
+                }
+
+                poolOfRecvSendEvents.Enqueue(sendEventArg);
+            }
+        }
+    }
+}

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Network/SockDataToken.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Network/SockDataToken.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Spark.CSharp.Network
+{
+    /// <summary>
+    /// SockDataToken class is used to associate with the SocketAsyncEventArgs object.
+    /// Primarily, it is a way to pass state to the event handler.
+    /// </summary>
+    internal class SockDataToken
+    {
+        /// <summary>
+        /// Initializes a SockDataToken instance with a client socket and a dataBuf 
+        /// </summary>
+        /// <param name="clientSocket">The client socket</param>
+        /// <param name="dataBuf">A data buffer that holds the data</param>
+        public SockDataToken(SaeaSocketWrapper clientSocket, ByteBuf dataBuf)
+        {
+            ClientSocket = clientSocket;
+            Data = dataBuf;
+        }
+
+        /// <summary>
+        /// Reset this token
+        /// </summary>
+        public void Reset()
+        {
+            ClientSocket = null;
+            if (Data != null) Data.Release();
+            Data = null;
+        }
+
+        /// <summary>
+        /// Detach the data ownership.
+        /// </summary>
+        public ByteBuf DetachData()
+        {
+            var retData = Data;
+            Data = null;
+            return retData;
+        }
+
+        /// <summary>
+        /// Gets and sets the data
+        /// </summary>
+        public ByteBuf Data { get; private set; }
+
+        /// <summary>
+        /// Gets and sets the client socket.
+        /// </summary>
+        public SaeaSocketWrapper ClientSocket { get; private set; }
+    }
+}

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Network/SocketFactory.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Network/SocketFactory.cs
@@ -1,6 +1,16 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Microsoft.Spark.CSharp.Configuration;
+
+[assembly: InternalsVisibleTo("CSharpWorker")]
+[assembly: InternalsVisibleTo("Tests.Common")]
+[assembly: InternalsVisibleTo("AdapterTest")]
+[assembly: InternalsVisibleTo("WorkerTest")]
 namespace Microsoft.Spark.CSharp.Network
 {
     /// <summary>
@@ -9,8 +19,46 @@ namespace Microsoft.Spark.CSharp.Network
     /// The ISocket instance can be RioSocket object, if the configuration is set to RioSocket and
     /// only the application is running on a Windows OS that supports Registered IO socket.
     /// </summary>
-    public static class SocketFactory
+    internal static class SocketFactory
     {
+        private const string RiosockDll = "Riosock.dll";
+        private static SocketWrapperType sockWrapperType = SocketWrapperType.None;
+
+        /// <summary>
+        /// Set socket wrapper type only for internal use (unit test)
+        /// </summary>
+        internal static SocketWrapperType SocketWrapperType
+        {
+            get
+            {
+                if (sockWrapperType != SocketWrapperType.None)
+                {
+                    return sockWrapperType;
+                }
+
+                sockWrapperType = SocketWrapperType.Normal;
+                SocketWrapperType sockType;
+                if (!Enum.TryParse(Environment.GetEnvironmentVariable(ConfigurationService.CSharpSocketTypeEnvName), out sockType))
+                    return sockWrapperType;
+
+                switch (sockType)
+                {
+                    case SocketWrapperType.Rio:
+                        if (IsRioSockSupported())
+                        {
+                            sockWrapperType = SocketWrapperType.Rio;
+                        }
+                        break;
+                    case SocketWrapperType.Saea:
+                        sockWrapperType = sockType;
+                        break;
+                }
+
+                return sockWrapperType;
+            }
+            set { sockWrapperType = value; }
+        }
+
         /// <summary>
         /// Creates a ISocket instance based on the configuration and OS version.
         /// </summary>
@@ -21,7 +69,66 @@ namespace Microsoft.Spark.CSharp.Network
         /// </returns>
         public static ISocketWrapper CreateSocket()
         {
-            return new DefaultSocketWrapper();
+            switch (SocketWrapperType)
+            {
+                case SocketWrapperType.Normal:
+                    return new DefaultSocketWrapper();
+
+                case SocketWrapperType.Rio:
+                    return new RioSocketWrapper();
+
+                case SocketWrapperType.Saea:
+                    return new SaeaSocketWrapper();
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
         }
+
+        /// <summary>
+        /// Indicates whether current OS supports RIO socket.
+        /// </summary>
+        public static bool IsRioSockSupported()
+        {
+            // Check is running on Windows
+            var os = Environment.OSVersion;
+            var p = (int) os.Platform;
+            var isWindows = (p != 4) && (p != 6) && (p != 128);
+            if (!isWindows) return false;
+
+            // Check windows version, RIO is only supported on Win8 and above
+            var osVersion = os.Version;
+            if (osVersion.Major <= 6 && (osVersion.Major != 6 || osVersion.Minor < 2)) return false;
+
+            // Check whether Riosock.dll exists, the Riosock.dll should be in the same folder with current assembly.
+            var localDir = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath) ?? ".";
+            return File.Exists(Path.Combine(localDir, RiosockDll));
+        }
+    }
+
+    /// <summary>
+    /// SocketWrapperType defines the socket wrapper type be used in transport.
+    /// </summary>
+    internal enum SocketWrapperType
+    {
+        /// <summary>
+        /// None
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Indicates CSharp code use System.Net.Sockets.Socket as transport
+        /// </summary>
+        Normal,
+
+        /// <summary>
+        /// Indicates CSharp code use Windows RIO socket as transport
+        /// </summary>
+        Rio,
+
+        /// <summary>
+        /// Indicates CSharp code use System.Net.Sockets.Socket with SocketAsyncEventArgs as transport
+        /// </summary>
+        Saea
     }
 }

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Network/SocketStream.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Network/SocketStream.cs
@@ -1,0 +1,184 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace Microsoft.Spark.CSharp.Network
+{
+    /// <summary>
+    /// Provides the underlying stream of data for network access.
+    /// Just like a NetworkStream.
+    /// </summary>
+    internal class SocketStream: Stream
+    {
+        private readonly ByteBufPool bufPool;
+        private readonly ISocketWrapper streamSocket;
+        private ByteBuf recvDataCache;
+
+        /// <summary>
+        /// Initializes a SocketStream with a SaeaSocketWrapper object.
+        /// </summary>
+        /// <param name="socket">a SaeaSocketWrapper object</param>
+        public SocketStream(SaeaSocketWrapper socket)
+        {
+            if (socket == null)
+            {
+                throw new ArgumentNullException("socket");
+            }
+            streamSocket = socket;
+            bufPool = ByteBufPool.Default;
+        }
+
+        /// <summary>
+        /// Initializes a SocketStream with a RioSocketWrapper object.
+        /// </summary>
+        /// <param name="socket">a RioSocketWrapper object</param>
+        public SocketStream(RioSocketWrapper socket)
+        {
+            if (socket == null)
+            {
+                throw new ArgumentNullException("socket");
+            }
+            streamSocket = socket;
+            bufPool = ByteBufPool.UnsafeDefault;
+        }
+
+        /// <summary>
+        /// Indicates that data can be read from the stream.
+        /// This property always returns <see langword='true'/>
+        /// </summary>
+        public override bool CanRead { get { return true; } }
+
+        /// <summary>
+        /// Indicates that the stream can seek a specific location in the stream.
+        /// This property always returns <see langword='false'/>
+        /// </summary>
+        public override bool CanSeek { get { return false; } }
+
+        /// <summary>
+        /// Indicates that data can be written to the stream.
+        /// This property always returns <see langword='true'/>
+        /// </summary>
+        public override bool CanWrite { get { return true; } }
+
+        /// <summary>
+        /// The length of data available on the stream.
+        /// Always throws <see cref='NotSupportedException'/>.
+        /// </summary>
+        public override long Length { get{ throw new NotSupportedException("This stream does not support seek operations."); } }
+
+        /// <summary>
+        /// Gets or sets the position in the stream.
+        /// Always throws <see cref='NotSupportedException'/>.
+        /// </summary>
+        public override long Position
+        {
+            get
+            {
+                throw new NotSupportedException("This stream does not support seek operations.");
+            }
+
+            set
+            {
+                throw new NotSupportedException("This stream does not support seek operations.");
+            }
+        }
+
+        /// <summary>
+        /// Flushes data from the stream.  This is meaningless for us, so it does nothing.
+        /// </summary>
+        public override void Flush()
+        {
+        }
+
+        /// <summary>
+        /// Seeks a specific position in the stream. This method is not supported
+        /// by the SocketDataStream class.
+        /// </summary>
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException("This stream does not support seek operations.");
+        }
+
+        /// <summary>
+        /// Sets the length of the stream. This method is not supported by the SocketDataStream class.
+        /// </summary>
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException("This stream does not support seek operations.");
+        }
+
+
+        /// <summary>
+        /// Reads a byte from the stream and advances the position within the stream by one byte, or returns -1 if at the end of the stream.
+        /// </summary>
+        /// <returns>
+        /// The unsigned byte cast to an Int32, or -1 if at the end of the stream.
+        /// </returns>
+        public override int ReadByte()
+        {
+            if (!recvDataCache.IsReadable())
+            {
+                recvDataCache = streamSocket.Receive();
+            }
+
+            return recvDataCache.ReadByte();
+        }
+
+        /// <summary>
+        /// Reads data from the stream.
+        /// </summary>
+        /// <param name="buffer">Buffer to read into.</param>
+        /// <param name="offset">Offset into the buffer where we're to read.</param>
+        /// <param name="count">Number of bytes to read.</param>
+        /// <returns>Number of bytes we read.</returns>
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            int bytesRemaining = count;
+
+            if (recvDataCache == null || !recvDataCache.IsReadable())
+            {
+                recvDataCache = streamSocket.Receive();
+            }
+
+            while (recvDataCache.IsReadable() && bytesRemaining > 0)
+            {
+                var bytesToRead = Math.Min(bytesRemaining, recvDataCache.ReadableBytes);
+                var n = recvDataCache.ReadBytes(buffer, offset + count - bytesRemaining, bytesToRead);
+                if (!recvDataCache.IsReadable())
+                {
+                    recvDataCache.Release();
+                    if (streamSocket.HasData)
+                    {
+                        recvDataCache = streamSocket.Receive();
+                    }
+                }
+
+                bytesRemaining -= n;
+            }
+
+            return count - bytesRemaining;
+        }
+
+        /// <summary>
+        /// Writes data to the stream.
+        /// </summary>
+        /// <param name="buffer">Buffer to write from.</param>
+        /// <param name="offset">Offset into the buffer from where we'll start writing.</param>
+        /// <param name="count">Number of bytes to write.</param>
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            var remainingBytes = count;
+            while (0 < remainingBytes)
+            {
+                var sendBuffer = bufPool.Allocate();
+                var sendCount = Math.Min(sendBuffer.WritableBytes, remainingBytes);
+                sendBuffer.WriteBytes(buffer, offset, sendCount);
+                streamSocket.Send(sendBuffer);
+                remainingBytes -= sendCount;
+            }
+        }
+    }
+}

--- a/csharp/Adapter/documentation/Microsoft.Spark.CSharp.Adapter.Doc.XML
+++ b/csharp/Adapter/documentation/Microsoft.Spark.CSharp.Adapter.Doc.XML
@@ -10,21 +10,6 @@
             to be used in SparkCLR runtime
             </summary>
         </member>
-        <member name="T:Microsoft.Spark.CSharp.Configuration.IConfigurationService">
-            <summary>
-            Helps getting config settings to be used in SparkCLR runtime
-            </summary>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Configuration.IConfigurationService.GetCSharpWorkerExePath">
-            <summary>
-            The full path of the CSharp external backend worker process executable.
-            </summary>
-        </member>
-        <member name="P:Microsoft.Spark.CSharp.Configuration.IConfigurationService.BackendPortNumber">
-            <summary>
-            The port number used for communicating with the CSharp external backend worker process.
-            </summary>
-        </member>
         <member name="T:Microsoft.Spark.CSharp.Configuration.ConfigurationService.SparkCLRConfiguration">
             <summary>
             Default configuration for SparkCLR jobs.
@@ -45,9 +30,6 @@
         <member name="T:Microsoft.Spark.CSharp.Configuration.ConfigurationService.SparkCLRLocalConfiguration">
             <summary>
             Configuration for SparkCLR jobs in ** Local ** mode
-            Needs some investigation to find out why Local mode behaves
-            different than standalone cluster mode for the configuration values
-            overridden here
             </summary>
         </member>
         <member name="T:Microsoft.Spark.CSharp.Configuration.ConfigurationService.SparkCLRDebugConfiguration">
@@ -91,6 +73,21 @@
             Indicates service is running in Yarn
             </summary>
         </member>
+        <member name="T:Microsoft.Spark.CSharp.Configuration.IConfigurationService">
+            <summary>
+            Helps getting config settings to be used in SparkCLR runtime
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Configuration.IConfigurationService.BackendPortNumber">
+            <summary>
+            The port number used for communicating with the CSharp external backend worker process.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Configuration.IConfigurationService.GetCSharpWorkerExePath">
+            <summary>
+            The full path of the CSharp external backend worker process executable.
+            </summary>
+        </member>
         <member name="T:Microsoft.Spark.CSharp.Core.Accumulator">
             <summary>
             A shared variable that can be accumulated, i.e., has a commutative and associative "add"
@@ -130,6 +127,12 @@
             <param name="accumulatorId">The Identity of the accumulator</param>
             <param name="value">The value of the accumulator</param>
         </member>
+        <member name="P:Microsoft.Spark.CSharp.Core.Accumulator`1.Value">
+            <summary>
+            Gets or sets the value of the accumulator; only usable in driver program
+            </summary>
+            <exception cref="T:System.ArgumentException"></exception>
+        </member>
         <member name="M:Microsoft.Spark.CSharp.Core.Accumulator`1.Add(`0)">
             <summary>
             Adds a term to this accumulator's value
@@ -150,12 +153,6 @@
             Creates and returns a string representation of the current accumulator
             </summary>
             <returns>A string representation of the current accumulator</returns>
-        </member>
-        <member name="P:Microsoft.Spark.CSharp.Core.Accumulator`1.Value">
-            <summary>
-            Gets or sets the value of the accumulator; only usable in driver program
-            </summary>
-            <exception cref="T:System.ArgumentException"></exception>
         </member>
         <member name="T:Microsoft.Spark.CSharp.Core.AccumulatorParam`1">
             <summary>
@@ -219,16 +216,16 @@
             </summary>
             <typeparam name="T">The type of element in Broadcast</typeparam>
         </member>
+        <member name="P:Microsoft.Spark.CSharp.Core.Broadcast`1.Value">
+            <summary>
+            Return the broadcasted value
+            </summary>
+        </member>
         <member name="M:Microsoft.Spark.CSharp.Core.Broadcast`1.Unpersist(System.Boolean)">
             <summary>
             Delete cached copies of this broadcast on the executors.
             </summary>
             <param name="blocking"></param>
-        </member>
-        <member name="P:Microsoft.Spark.CSharp.Core.Broadcast`1.Value">
-            <summary>
-            Return the broadcasted value
-            </summary>
         </member>
         <member name="T:Microsoft.Spark.CSharp.Core.Option`1">
             <summary>
@@ -248,17 +245,17 @@
             </summary>
             <param name="value">The value to be associated with the new instance.</param>
         </member>
+        <member name="P:Microsoft.Spark.CSharp.Core.Option`1.IsDefined">
+            <summary>
+            Indicates whether the option value is defined.
+            </summary>
+        </member>
         <member name="M:Microsoft.Spark.CSharp.Core.Option`1.GetValue">
             <summary>
             Returns the value of the option if Option.IsDefined is TRUE;
             otherwise, throws an <see cref="T:System.ArgumentException"/>.
             </summary>
             <returns></returns>
-        </member>
-        <member name="P:Microsoft.Spark.CSharp.Core.Option`1.IsDefined">
-            <summary>
-            Indicates whether the option value is defined.
-            </summary>
         </member>
         <member name="T:Microsoft.Spark.CSharp.Core.Partitioner">
             <summary>
@@ -294,11 +291,6 @@
         <member name="T:Microsoft.Spark.CSharp.Core.RDDCollector">
             <summary>
             Used for collect operation on RDD
-            </summary>
-        </member>
-        <member name="T:Microsoft.Spark.CSharp.Core.IRDDCollector">
-            <summary>
-            Interface for collect operation on RDD
             </summary>
         </member>
         <member name="T:Microsoft.Spark.CSharp.Core.DoubleRDDFunctions">
@@ -417,6 +409,11 @@
             </summary>
             <param name="self"></param>
             <returns></returns>
+        </member>
+        <member name="T:Microsoft.Spark.CSharp.Core.IRDDCollector">
+            <summary>
+            Interface for collect operation on RDD
+            </summary>
         </member>
         <member name="T:Microsoft.Spark.CSharp.Core.OrderedRDDFunctions">
             <summary>
@@ -1055,6 +1052,14 @@
             <param name="path">path to sequence file</param>
             <param name="compressionCodecClass">(None by default)</param>
         </member>
+        <member name="T:Microsoft.Spark.CSharp.Core.PairRDDFunctions.GroupByMergeHelper`2">
+            <summary>
+            These classes are defined explicitly and marked as [Serializable]instead of using anonymous method as delegate to 
+            prevent C# compiler from generating private anonymous type that is not serializable. Since the delegate has to be 
+            serialized and sent to the Spark workers for execution, it is necessary to have the type marked [Serializable]. 
+            These classes are to work around the limitation on the serializability of compiler generated types
+            </summary>
+        </member>
         <member name="M:Microsoft.Spark.CSharp.Core.PairRDDFunctions.NullIfEmpty``1(System.Collections.Generic.IEnumerable{``0})">
             <summary>
             Converts a collection to a list where the element type is Option(T) type.
@@ -1064,20 +1069,35 @@
             <typeparam name="T">The element type in the collection</typeparam>
             <returns>A list that use Option(T) as element type</returns>
         </member>
-        <member name="T:Microsoft.Spark.CSharp.Core.PairRDDFunctions.GroupByMergeHelper`2">
-            <summary>
-            These classes are defined explicitly and marked as [Serializable]instead of using anonymous method as delegate to 
-            prevent C# compiler from generating private anonymous type that is not serializable. Since the delegate has to be 
-            serialized and sent to the Spark workers for execution, it is necessary to have the type marked [Serializable]. 
-            These classes are to work around the limitation on the serializability of compiler generated types
-            </summary>
-        </member>
         <member name="T:Microsoft.Spark.CSharp.Core.PipelinedRDD`1">
             <summary>
             Wraps C#-based transformations that can be executed within a stage. It helps avoid unnecessary Ser/De of data between
             JVM and CLR to execute C# transformations and pipelines them
             </summary>
             <typeparam name="U"></typeparam>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Core.PipelinedRDD`1.MapPartitionsWithIndex``1(System.Func{System.Int32,System.Collections.Generic.IEnumerable{`0},System.Collections.Generic.IEnumerable{``0}},System.Boolean)">
+            <summary>
+            Return a new RDD by applying a function to each partition of this RDD,
+            while tracking the index of the original partition.
+            </summary>
+            <typeparam name="U1">The element type</typeparam>
+            <param name="newFunc">The function to be applied to each partition</param>
+            <param name="preservesPartitioningParam">Indicates if it preserves partition parameters</param>
+            <returns>A new RDD</returns>
+        </member>
+        <member name="T:Microsoft.Spark.CSharp.Core.PipelinedRDD`1.MapPartitionsWithIndexHelper`2">
+            <summary>
+            This class is defined explicitly instead of using anonymous method as delegate to prevent C# compiler from generating
+            private anonymous type that is not serializable. Since the delegate has to be serialized and sent to the Spark workers
+            for execution, it is necessary to have the type marked [Serializable]. This class is to work around the limitation
+            on the serializability of compiler generated types
+            </summary>
+        </member>
+        <member name="T:Microsoft.Spark.CSharp.Core.Profiler">
+            <summary>
+            A class represents a profiler
+            </summary>
         </member>
         <member name="T:Microsoft.Spark.CSharp.Core.RDD`1">
             <summary>
@@ -1096,6 +1116,21 @@
         <member name="F:Microsoft.Spark.CSharp.Core.RDD`1.isCheckpointed">
             <summary>
             Indicates whether the RDD is checkpointed.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Core.RDD`1.IsCached">
+            <summary>
+            Return whether this RDD has been cached or not
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Core.RDD`1.IsCheckpointed">
+            <summary>
+            Return whether this RDD has been checkpointed or not
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Core.RDD`1.Name">
+            <summary>
+            Return the name of this RDD.
             </summary>
         </member>
         <member name="M:Microsoft.Spark.CSharp.Core.RDD`1.Cache">
@@ -1654,7 +1689,7 @@
             n is the number of partitions. So there may exist gaps, but this
             method won't trigger a spark job, which is different from <see cref="M:Microsoft.Spark.CSharp.Core.RDD`1.ZipWithIndex"/>
             
-            &gt;&gt;&gt; sc.Parallelize(new string[] { "a", "b", "c", "d" }, 1).ZipWithIndex().Collect()
+            >>> sc.Parallelize(new string[] { "a", "b", "c", "d" }, 1).ZipWithIndex().Collect()
             [('a', 0), ('b', 1), ('c', 4), ('d', 2), ('e', 5)]
             
             </summary>
@@ -1707,44 +1742,6 @@
             <param name="ub">upper bound to use for the Bernoulli sampler</param>
             <param name="seed">the seed for the Random number generator</param>
             <returns>A random sub-sample of the RDD without replacement.</returns>
-        </member>
-        <member name="P:Microsoft.Spark.CSharp.Core.RDD`1.IsCached">
-            <summary>
-            Return whether this RDD has been cached or not
-            </summary>
-        </member>
-        <member name="P:Microsoft.Spark.CSharp.Core.RDD`1.IsCheckpointed">
-            <summary>
-            Return whether this RDD has been checkpointed or not
-            </summary>
-        </member>
-        <member name="P:Microsoft.Spark.CSharp.Core.RDD`1.Name">
-            <summary>
-            Return the name of this RDD.
-            </summary>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Core.PipelinedRDD`1.MapPartitionsWithIndex``1(System.Func{System.Int32,System.Collections.Generic.IEnumerable{`0},System.Collections.Generic.IEnumerable{``0}},System.Boolean)">
-            <summary>
-            Return a new RDD by applying a function to each partition of this RDD,
-            while tracking the index of the original partition.
-            </summary>
-            <typeparam name="U1">The element type</typeparam>
-            <param name="newFunc">The function to be applied to each partition</param>
-            <param name="preservesPartitioningParam">Indicates if it preserves partition parameters</param>
-            <returns>A new RDD</returns>
-        </member>
-        <member name="T:Microsoft.Spark.CSharp.Core.PipelinedRDD`1.MapPartitionsWithIndexHelper`2">
-            <summary>
-            This class is defined explicitly instead of using anonymous method as delegate to prevent C# compiler from generating
-            private anonymous type that is not serializable. Since the delegate has to be serialized and sent to the Spark workers
-            for execution, it is necessary to have the type marked [Serializable]. This class is to work around the limitation
-            on the serializability of compiler generated types
-            </summary>
-        </member>
-        <member name="T:Microsoft.Spark.CSharp.Core.Profiler">
-            <summary>
-            A class represents a profiler
-            </summary>
         </member>
         <member name="T:Microsoft.Spark.CSharp.Core.StringRDDFunctions">
             <summary>
@@ -1954,6 +1951,36 @@
         <member name="M:Microsoft.Spark.CSharp.Core.SparkContext.GetActiveSparkContext">
             <summary>
             Get existing SparkContext
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Core.SparkContext.Version">
+            <summary>
+            The version of Spark on which this application is running.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Core.SparkContext.StartTime">
+            <summary>
+            Return the epoch time when the Spark Context was started.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Core.SparkContext.DefaultParallelism">
+            <summary>
+            Default level of parallelism to use when not given by user (e.g. for reduce tasks)
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Core.SparkContext.DefaultMinPartitions">
+            <summary>
+            Default min number of partitions for Hadoop RDDs when not given by user
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Core.SparkContext.SparkUser">
+            <summary>
+            Get SPARK_USER for user who is running SparkContext.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Core.SparkContext.StatusTracker">
+            <summary>
+            Return :class:`StatusTracker` object
             </summary>
         </member>
         <member name="M:Microsoft.Spark.CSharp.Core.SparkContext.#ctor(System.String,System.String,System.String)">
@@ -2298,36 +2325,6 @@
             Cancel all jobs that have been scheduled or are running.
             </summary>
         </member>
-        <member name="P:Microsoft.Spark.CSharp.Core.SparkContext.Version">
-            <summary>
-            The version of Spark on which this application is running.
-            </summary>
-        </member>
-        <member name="P:Microsoft.Spark.CSharp.Core.SparkContext.StartTime">
-            <summary>
-            Return the epoch time when the Spark Context was started.
-            </summary>
-        </member>
-        <member name="P:Microsoft.Spark.CSharp.Core.SparkContext.DefaultParallelism">
-            <summary>
-            Default level of parallelism to use when not given by user (e.g. for reduce tasks)
-            </summary>
-        </member>
-        <member name="P:Microsoft.Spark.CSharp.Core.SparkContext.DefaultMinPartitions">
-            <summary>
-            Default min number of partitions for Hadoop RDDs when not given by user
-            </summary>
-        </member>
-        <member name="P:Microsoft.Spark.CSharp.Core.SparkContext.SparkUser">
-            <summary>
-            Get SPARK_USER for user who is running SparkContext.
-            </summary>
-        </member>
-        <member name="P:Microsoft.Spark.CSharp.Core.SparkContext.StatusTracker">
-            <summary>
-            Return :class:`StatusTracker` object
-            </summary>
-        </member>
         <member name="T:Microsoft.Spark.CSharp.Core.StatCounter">
             <summary>
             A class for tracking the statistics of a set of numbers (count, mean and variance) in a numerically
@@ -2373,14 +2370,6 @@
             </summary>
             <returns></returns>
         </member>
-        <member name="M:Microsoft.Spark.CSharp.Core.StatCounter.ToString">
-            <summary>
-            Returns a string that represents this StatCounter.
-            </summary>
-            <returns>
-            A string that represents this StatCounter.
-            </returns>
-        </member>
         <member name="P:Microsoft.Spark.CSharp.Core.StatCounter.Count">
             <summary>
             Gets the count number of this StatCounter
@@ -2425,6 +2414,14 @@
             <summary>
             Return the sample standard deviation of the values, which corrects for bias in estimating the variance by dividing by N-1 instead of N.
             </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Core.StatCounter.ToString">
+            <summary>
+            Returns a string that represents this StatCounter.
+            </summary>
+            <returns>
+            A string that represents this StatCounter.
+            </returns>
         </member>
         <member name="T:Microsoft.Spark.CSharp.Core.StatusTracker">
             <summary>
@@ -2659,10 +2656,56 @@
             Utility methods for C#-JVM interaction
             </summary>
         </member>
-        <member name="T:Microsoft.Spark.CSharp.Interop.SparkCLREnvironment">
+        <member name="T:Microsoft.Spark.CSharp.Interop.Ipc.IWeakObjectManager">
             <summary>
-            Contains everything needed to setup an environment for using C# with Spark
+            Release JVMObjectTracker oject reference.
+            The reason is for the inter-operation from CSharp to Java :
+            1.Java-side: https://github.com/Microsoft/Mobius/blob/master/scala/src/main/org/apache/spark/api/csharp/CSharpBackendHandler.scala#L269
+                JVMObjectTracker keep a HashMap[String, Object] which is [id, Java-object]
+            2.CSharp-side :
+            1) JvmObjectReference remember the id : https://github.com/Microsoft/Mobius/blob/master/csharp/Adapter/Microsoft.Spark.CSharp/Interop/Ipc/JvmObjectReference.cs#L20 
+            2) So JvmBridge can call java object's method https://github.com/Microsoft/Mobius/blob/master/csharp/Adapter/Microsoft.Spark.CSharp/Interop/Ipc/JvmBridge.cs#L69
+            
+            So potential memory leak can happen in JVMObjectTracker.
+            To solve this, track the garbage collection in CSharp side, get the id, release JVMObjectTracker's HashMap. 
             </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Interop.Ipc.IWeakObjectManager.GetReferencesCount">
+            <summary>
+            Gets all weak object count including non-alive objects that wait for releasing.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Interop.Ipc.IWeakObjectManager.GetAliveCount">
+            <summary>
+            Gets alive weak object count
+            </summary>
+            <returns></returns>
+        </member>
+        <member name="T:Microsoft.Spark.CSharp.Interop.Ipc.WeakReferenceCheckCountController">
+            <summary>
+            adaptively control the number of weak objects that should be checked for each interval
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Interop.Ipc.WeakReferenceCheckCountController.AdjustCheckCount(System.Int32)">
+            <summary>
+            Adjust checkCount adaptively according to current weak reference objects count
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Interop.Ipc.WeakObjectManagerImpl.CheckInterval">
+            <summary>
+            Sleep time for checking thread
+            </summary>
+        </member>
+        <member name="F:Microsoft.Spark.CSharp.Interop.Ipc.WeakObjectManagerImpl.MaxReleasingDuration">
+            <summary>
+            Maximum running duration for checking thread each time
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Interop.Ipc.WeakObjectManagerImpl.GetAliveCount">
+            <summary>
+            It can be an expensive operation. ** Do not use ** unless there is a real need for this method
+            </summary>
+            <returns></returns>
         </member>
         <member name="T:Microsoft.Spark.CSharp.Interop.Ipc.IJvmBridge">
             <summary>
@@ -2881,50 +2924,447 @@
             <param name="s">The stream to write</param>
             <param name="value">The string to write</param>
         </member>
+        <member name="T:Microsoft.Spark.CSharp.Interop.SparkCLREnvironment">
+            <summary>
+            Contains everything needed to setup an environment for using C# with Spark
+            </summary>
+        </member>
+        <member name="T:Microsoft.Spark.CSharp.Network.ByteBuf">
+            <summary>
+            ByteBuf delimits a section of a ByteBufChunk.
+            It is the smallest unit to be allocated.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Spark.CSharp.Network.ByteBuf.Status">
+            <summary>
+            Indicates the state of that the ByteBuf as socket data transport.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBuf.#ctor(Microsoft.Spark.CSharp.Network.ByteBufChunk,System.Int32,System.Int32)">
+            <summary>
+            We borrow some ideas from Netty's ByteBuf. 
+            ByteBuf provides two pointer variables to support sequential read and write operations
+             - readerIndex for a read operation and writerIndex for a write operation respectively.
+            The following diagram shows how a buffer is segmented into three areas by the two
+            pointers:
+            
+                 +-------------------+------------------+------------------+
+                 | discardable bytes |  readable bytes  |  writable bytes  |
+                 |                   |     (CONTENT)    |                  |
+                 +-------------------+------------------+------------------+
+                 |                   |                  |                  |
+                 0       ==     readerIndex   ==   writerIndex    ==    capacity
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBuf.Array">
+            <summary>
+            Gets the underlying array.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBuf.Capacity">
+            <summary>
+            Gets the total number of elements in the range delimited by the ByteBuf.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBuf.Offset">
+            <summary>
+            Gets the position of the first element in the range delimited
+            by the ByteBuf, relative to the start of the original array.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBuf.ByteBufChunk">
+            <summary>
+            Returns the ByteBuf chunk that contains this ByteBuf.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBuf.ReadableBytes">
+            <summary>
+            Returns the number of readable bytes which is equal to (writerIndex - readerIndex).
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBuf.WritableBytes">
+            <summary>
+            Returns the number of writable bytes which is equal to (capacity - writerIndex).
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBuf.UnsafeArray">
+            <summary>
+            Gets the underlying unsafe array.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBuf.ReaderIndex">
+            <summary>
+            Gets or sets the readerIndex of this ByteBuf
+            </summary>
+            <exception cref="T:System.IndexOutOfRangeException"></exception>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBuf.WriterIndex">
+            <summary>
+            Gets or sets the writerIndex of this ByteBuf
+            </summary>
+            <exception cref="T:System.IndexOutOfRangeException"></exception>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBuf.ReaderIndexOffset">
+            <summary>
+            Returns the position of the readerIndex element in the range delimited
+            by the ByteBuf, relative to the start of the original array.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBuf.WriterIndexOffset">
+            <summary>
+            Returns the position of the readerIndex element in the range delimited
+            by the ByteBuf, relative to the start of the original array.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBuf.Clear">
+            <summary>
+            Sets the readerIndex and writerIndex of this buffer to 0.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBuf.IsReadable(System.Int32)">
+            <summary>
+            Is this ByteSegment readable if and only if the buffer contains equal or more than
+            the specified number of elements
+            </summary>
+            <param name="size">
+            The number of elements we would like to read,
+            The default value is 1 that is to check this ByteBuf has at least 1 byte can be read.
+            </param>
+            <returns>true, if it is readable; otherwise, false</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBuf.IsWritable(System.Int32)">
+            <summary>
+                Returns true if and only if the buffer has enough Capacity to accommodate size
+                additional bytes.
+            </summary>
+            <param name="size">
+            The number of additional elements we would like to write
+            The default value is 1 that is to check this ByteBuf has at least 1 byte can be wroten.
+            </param>
+            <returns>true, if this ByteSegment is writable; otherwise, false</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBuf.ReadByte">
+            <summary>
+            Gets a byte at the current readerIndex and increases the readerIndex by 1 in this buffer.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBuf.ReadBytes(System.Byte[],System.Int32,System.Int32)">
+            <summary>
+            Reads a block of bytes from the ByteBuf and writes the data to a buffer.
+            </summary>
+            <param name="buffer">
+            When this method returns, contains the specified byte array with the values
+            between offset and (offset + count - 1) replaced by the characters read
+             from the ByteBuf. 
+            </param>
+            <param name="offset">The zero-based byte offset in buffer at which to begin storing data from the ByteBuf.</param>
+            <param name="count">The maximum number of bytes to read.</param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBuf.Release">
+            <summary>
+            Release the ByteBuf back to the ByteBufPool
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBuf.WriteBytes(System.Byte[],System.Int32,System.Int32)">
+            <summary>
+            Writes a block of bytes to the ByteBuf using data read from a buffer.
+            </summary>
+            <param name="buffer">The buffer to write data from. </param>
+            <param name="offset">The zero-based byte offset in buffer at which to begin copying bytes to the ByteBuf.</param>
+            <param name="count">The maximum number of bytes to write.</param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBuf.GetInputRioBuf">
+            <summary>
+            Returns a RioBuf object for input (receive)
+            </summary>
+            <returns>A RioBuf object</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBuf.GetOutputRioBuf">
+            <summary>
+            Returns a RioBuf object for output (send).
+            </summary>
+            <returns>A RioBuf object</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBuf.NewErrorStatusByteBuf(System.Int32)">
+            <summary>
+            Creates an empty ByteBuf with error status.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Spark.CSharp.Network.ByteBufChunk">
+            <summary>
+            ByteBufChunk represents a memory blocks that can be allocated from 
+            .Net heap (managed code) or process heap(unsafe code)
+            </summary>
+        </member>
+        <member name="F:Microsoft.Spark.CSharp.Network.ByteBufChunk.Parent">
+            <summary>
+            The ByteBufChunkList that contains this ByteBufChunk
+            </summary>
+        </member>
+        <member name="F:Microsoft.Spark.CSharp.Network.ByteBufChunk.Prev">
+            <summary>
+            The previous ByteBufChunk in linked like list
+            </summary>
+        </member>
+        <member name="F:Microsoft.Spark.CSharp.Network.ByteBufChunk.Next">
+            <summary>
+            The next ByteBufChunk in linked like list
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBufChunk.Finalize">
+            <summary>
+            Finalizer.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBufChunk.Array">
+            <summary>
+            Returns the underlying array that is used for managed code.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBufChunk.BufId">
+            <summary>
+            Returns the buffer Id that registered as RIO buffer.
+            Only apply to unsafe ByteBufChunk
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBufChunk.FreeBytes">
+            <summary>
+            Returns the unused bytes in this chunk.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBufChunk.IsDisposed">
+            <summary>
+            Indicates whether this ByteBufChunk is disposed.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBufChunk.IsUnsafe">
+            <summary>
+            Indicates whether the underlying buffer array is a unsafe type array.
+            The unsafe array is used for PInvoke with native code.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBufChunk.Pool">
+            <summary>
+            Returns the ByteBufPool that this ByteBufChunk belongs to.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBufChunk.Size">
+            <summary>
+            Returns the size of the ByteBufChunk
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBufChunk.Usage">
+            <summary>
+            Returns the percentage of the current usage of the chunk
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBufChunk.UnsafeArray">
+            <summary>
+            Returns the IntPtr that points to beginning of the cached heap block.
+            This is used for PInvoke with native code.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBufChunk.Allocate(Microsoft.Spark.CSharp.Network.ByteBuf@)">
+            <summary>
+            Allocates a ByteBuf from this ByteChunk.
+            </summary>
+            <param name="byteBuf">The ByteBuf be allocated</param>
+            <returns>true, if succeed to allocate a ByteBuf; otherwise, false</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBufChunk.Dispose">
+            <summary>
+            Release all resources
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBufChunk.Free(Microsoft.Spark.CSharp.Network.ByteBuf)">
+            <summary>
+            Releases the ByteBuf back to this ByteChunk
+            </summary>
+            <param name="byteBuf">The ByteBuf to be released.</param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBufChunk.ToString">
+            <summary>
+            Returns a readable string for the ByteBufChunk
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBufChunk.NewChunk(Microsoft.Spark.CSharp.Network.ByteBufPool,System.Int32,System.Int32,System.Boolean)">
+            <summary>
+            Static method to create a new ByteBufChunk with given segment and chunk size.
+            If isUnsafe is true, it allocates memory from the process's heap.
+            </summary>
+            <param name="pool">The ByteBufPool that contains the new ByteChunk</param>
+            <param name="segmentSize">The segment size</param>
+            <param name="chunkSize">The chunk size to create</param>
+            <param name="isUnsafe">Indicates if it is a safe or unsafe</param>
+            <returns>The new ByteBufChunk object</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBufChunk.FreeToProcessHeap(System.IntPtr)">
+            <summary>
+            Wraps HeapFree to process heap.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBufChunk.Dispose(System.Boolean)">
+            <summary>
+                Implementation of the Dispose pattern.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Spark.CSharp.Network.ByteBufChunk.Segment">
+            <summary>
+            Segment struct delimits a section of a byte chunk.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Spark.CSharp.Network.ByteBufChunkList">
+            <summary>
+            ByteBufChunkList class represents a simple linked like list used to store ByteBufChunk objects
+            based on its usage.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Spark.CSharp.Network.ByteBufChunkList.PrevList">
+            <summary>
+            The previous ByteBufChunkList. This is only update once when create the linked like list
+            of ByteBufChunkList in ByteBufPool constructor.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBufChunkList.#ctor(Microsoft.Spark.CSharp.Network.ByteBufChunkList,System.Int32,System.Int32)">
+            <summary>
+            Initializes a ByteBufChunkList instance with the next ByteBufChunkList and minUsage and maxUsage
+            </summary>
+            <param name="nextList">The next item of this ByteBufChunkList</param>
+            <param name="minUsage">The definition of minimum usage to contain ByteBufChunk</param>
+            <param name="maxUsage">The definition of maximum usage to contain ByteBufChunk</param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBufChunkList.Add(Microsoft.Spark.CSharp.Network.ByteBufChunk)">
+            <summary>
+            Add the ByteBufChunk to this ByteBufChunkList linked-list based on ByteBufChunk's usage.
+            So it will be moved to the right ByteBufChunkList that has the correct minUsage/maxUsage.
+            </summary>
+            <param name="chunk">The ByteBufChunk to be added</param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBufChunkList.Allocate(Microsoft.Spark.CSharp.Network.ByteBuf@)">
+            <summary>
+            Allocates a ByteBuf from this ByteBufChunkList if it is not empty.
+            </summary>
+            <param name="byteBuf">The allocated ByteBuf</param>
+            <returns>true, if the ByteBuf be allocated; otherwise, false.</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBufChunkList.Free(Microsoft.Spark.CSharp.Network.ByteBufChunk,Microsoft.Spark.CSharp.Network.ByteBuf)">
+            <summary>
+            Releases the segment back to its ByteBufChunk.
+            </summary>
+            <param name="chunk">The ByteBufChunk that contains the ByteBuf</param>
+            <param name="byteBuf">The ByteBuf to be released.</param>
+            <returns>
+            true, if the ByteBuf be released and NOT need to destroy the
+            ByteBufChunk (its usage is 0); otherwise, false.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBufChunkList.AddInternal(Microsoft.Spark.CSharp.Network.ByteBufChunk)">
+            <summary>
+            Adds the ByteBufChunk to this ByteBufChunkList
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBufChunkList.MoveInternal(Microsoft.Spark.CSharp.Network.ByteBufChunk)">
+            <summary>
+            Moves the ByteBufChunk down the ByteBufChunkList linked-list so it will end up in the right
+            ByteBufChunkList that has the correct minUsage/maxUsage in respect to ByteBufChunk.Usage.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBufChunkList.Remove(Microsoft.Spark.CSharp.Network.ByteBufChunk)">
+            <summary>
+            Remove the ByteBufChunk from this ByteBufChunkList
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBufChunkList.ToString">
+            <summary>
+            Returns a readable string for this ByteBufChunkList
+            </summary>
+        </member>
+        <member name="T:Microsoft.Spark.CSharp.Network.ByteBufPool">
+            <summary>
+            ByteBufPool class is used to manage the ByteBuf pool that allocate and free pooled memory buffer.
+            We borrows some ideas from Netty buffer memory management.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Spark.CSharp.Network.ByteBufPool.MaxChunkSize">
+            <summary>
+            The chunk size is calculated with given segment size and chunk order.
+            The MaxChunkSize ensure ByteBuf chunk Size (Int32.MaxValue) does not overflow.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Spark.CSharp.Network.ByteBufPool.DefaultSegmentSize">
+            <summary>
+            The default segment size to delimit a byte array chunk. 
+            </summary>
+        </member>
+        <member name="F:Microsoft.Spark.CSharp.Network.ByteBufPool.DefaultChunkOrder">
+            <summary>
+            The default chunk order used to calculate chunk size and ensure it is a multiple of a segment size.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBufPool.#ctor(System.Int32,System.Int32,System.Boolean)">
+            <summary>
+            Initializes a new ByteBufPool instance with a given segment size and chunk order.
+            If isUnsafe is true, all memory will be allocated from process's heap by using
+            native HeapAlloc API.
+            </summary>
+            <param name="segmentSize">The size of a segment</param>
+            <param name="chunkOrder">Used to caculate chunk size and ensures it is a multiple of a segment size</param>
+            <param name="isUnsafe">Indicates whether allocates memory from process's heap</param>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBufPool.Default">
+            <summary>
+            Gets the default byte buffer pool instance for managed memory.
+            </summary>
+            <remarks>
+            You should only be using this instance to allocate/deallocate the managed memory arena
+            if you don't want to manage memory arena on your own.
+            </remarks>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBufPool.UnsafeDefault">
+            <summary>
+            Gets the default byte arena instance for unmanaged memory.
+            </summary>
+            <remarks>
+            You should only be using this instance to allocate/deallocate the unmanaged memory arena
+            if you don't want to manage memory arena on your own.
+            </remarks>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBufPool.SegmentSize">
+            <summary>
+            Returns the size of a ByteBuf in this ByteBufPool
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ByteBufPool.ChunkSize">
+            <summary>
+            Returns the size of a ByteChunk in this ByteBufPool
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBufPool.Allocate">
+            <summary>
+            Allocates a ByteBuf from this ByteBufPool to use.
+            </summary>
+            <returns>A ByteBuf contained in this ByteBufPool</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBufPool.Free(Microsoft.Spark.CSharp.Network.ByteBuf)">
+            <summary>
+            Deallocates a ByteBuf back to this ByteBufPool.
+            </summary>
+            <param name="byteBuf">The ByteBuf to be release.</param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBufPool.ToString">
+            <summary>
+            Gets a readable string for this ByteBufPool
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ByteBufPool.GetUsages">
+            <summary>
+            Returns the chunk numbers in each queue.
+            </summary>
+        </member>
         <member name="T:Microsoft.Spark.CSharp.Network.DefaultSocketWrapper">
             <summary>
             A simple wrapper of System.Net.Sockets.Socket class.
-            </summary>
-        </member>
-        <member name="T:Microsoft.Spark.CSharp.Network.ISocketWrapper">
-            <summary>
-            ISocketWrapper interface defines the common methods to operate a socket (traditional socket or 
-            Windows Registered IO socket)
-            </summary>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Network.ISocketWrapper.Accept">
-            <summary>
-            Accepts a incoming connection request.
-            </summary>
-            <returns>A ISocket instance used to send and receive data</returns>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Network.ISocketWrapper.Close">
-            <summary>
-            Close the ISocket connections and releases all associated resources.
-            </summary>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Network.ISocketWrapper.Connect(System.Net.IPAddress,System.Int32)">
-            <summary>
-            Establishes a connection to a remote host that is specified by an IP address and a port number
-            </summary>
-            <param name="remoteaddr">The IP address of the remote host</param>
-            <param name="port">The port number of the remote host</param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Network.ISocketWrapper.GetStream">
-            <summary>
-            Returns a stream used to send and receive data.
-            </summary>
-            <returns>The underlying Stream instance that be used to send and receive data</returns>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Network.ISocketWrapper.Listen(System.Int32)">
-            <summary>
-            Starts listening for incoming connections requests
-            </summary>
-            <param name="backlog">The maximum length of the pending connections queue. </param>
-        </member>
-        <member name="P:Microsoft.Spark.CSharp.Network.ISocketWrapper.LocalEndPoint">
-            <summary>
-            Returns the local endpoint.
             </summary>
         </member>
         <member name="M:Microsoft.Spark.CSharp.Network.DefaultSocketWrapper.#ctor">
@@ -2975,6 +3415,22 @@
             </summary>
             <param name="backlog">The maximum length of the pending connections queue. </param>
         </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.DefaultSocketWrapper.Receive">
+            <summary>
+            Receives network data from this socket, and returns a ByteBuf that contains the received data.
+            
+            The DefaultSocketWrapper does not support this function.
+            </summary>
+            <returns>A ByteBuf object that contains received data.</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.DefaultSocketWrapper.Send(Microsoft.Spark.CSharp.Network.ByteBuf)">
+            <summary>
+            Sends data to this socket with a ByteBuf object that contains data to be sent.
+            
+            The DefaultSocketWrapper does not support this function.
+            </summary>
+            <param name="data">A ByteBuf object that contains data to be sent</param>
+        </member>
         <member name="M:Microsoft.Spark.CSharp.Network.DefaultSocketWrapper.Dispose(System.Boolean)">
             <summary>
             Disposes the resources used by this instance of the DefaultSocket class.
@@ -2991,9 +3447,509 @@
             Frees resources used by DefaultSocket class
             </summary>
         </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.DefaultSocketWrapper.HasData">
+            <summary>
+            Indicates whether there are data that has been received from the network and is available to be read.
+            </summary>
+        </member>
         <member name="P:Microsoft.Spark.CSharp.Network.DefaultSocketWrapper.LocalEndPoint">
             <summary>
             Returns the local endpoint.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.DefaultSocketWrapper.RemoteEndPoint">
+            <summary>
+            Returns the remote endpoint if it has one.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Spark.CSharp.Network.ISocketWrapper">
+            <summary>
+            ISocketWrapper interface defines the common methods to operate a socket (traditional socket or 
+            Windows Registered IO socket)
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ISocketWrapper.Accept">
+            <summary>
+            Accepts a incoming connection request.
+            </summary>
+            <returns>A ISocket instance used to send and receive data</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ISocketWrapper.Close">
+            <summary>
+            Close the ISocket connections and releases all associated resources.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ISocketWrapper.Connect(System.Net.IPAddress,System.Int32)">
+            <summary>
+            Establishes a connection to a remote host that is specified by an IP address and a port number
+            </summary>
+            <param name="remoteaddr">The IP address of the remote host</param>
+            <param name="port">The port number of the remote host</param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ISocketWrapper.GetStream">
+            <summary>
+            Returns a stream used to send and receive data.
+            </summary>
+            <returns>The underlying Stream instance that be used to send and receive data</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ISocketWrapper.Listen(System.Int32)">
+            <summary>
+            Starts listening for incoming connections requests
+            </summary>
+            <param name="backlog">The maximum length of the pending connections queue. </param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ISocketWrapper.Receive">
+            <summary>
+            Receives network data from this socket, and returns a ByteBuf that contains the received data.
+            </summary>
+            <returns>A ByteBuf object that contains received data.</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ISocketWrapper.Send(Microsoft.Spark.CSharp.Network.ByteBuf)">
+            <summary>
+            Sends data to this socket with a ByteBuf object that contains data to be sent.
+            </summary>
+            <param name="data">A ByteBuf object that contains data to be sent</param>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ISocketWrapper.HasData">
+            <summary>
+            Indicates whether there are data that has been received from the network and is available to be read.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ISocketWrapper.LocalEndPoint">
+            <summary>
+            Returns the local endpoint.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.ISocketWrapper.RemoteEndPoint">
+            <summary>
+            Returns the remote endpoint
+            </summary>
+        </member>
+        <member name="T:Microsoft.Spark.CSharp.Network.RioNative">
+            <summary>
+            RioNative class imports and initializes RIOSock.dll for use with RIO socket APIs.
+            It also provided a simple thread pool that retrieves the results from IO completion port.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioNative.Finalize">
+            <summary>
+            Finalizer
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioNative.Dispose">
+            <summary>
+            Release all resources.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioNative.SetUseThreadPool(System.Boolean)">
+            <summary>
+            Sets whether use thread pool to query RIO socket results, 
+            it must be called before calling EnsureRioLoaded()
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.RioNative.ConnectionTable">
+            <summary>
+            Gets the connection table that contains all connections.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioNative.EnsureRioLoaded">
+            <summary>
+            Ensures that the native dll of RIO socket is loaded and initialized.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioNative.UnloadRio">
+            <summary>
+            Explicitly unload the native dll of RIO socket, and release resources.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioNative.Init">
+            <summary>
+            Initializes RIOSock native library.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Spark.CSharp.Network.RioResult">
+            <summary>
+            The RioResult structure contains data used to indicate request completion results used with RIO socket
+            </summary>
+        </member>
+        <member name="T:Microsoft.Spark.CSharp.Network.RioSocketWrapper">
+            <summary>
+            RioSocketWrapper class is a wrapper of a socket that use Windows RIO socket with IO
+            completion ports to implement socket operations.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioSocketWrapper.#ctor">
+            <summary>
+            Default ctor that creates a new instance of RioSocketWrapper class.
+            The instance binds to loop-back address with port 0.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioSocketWrapper.#ctor(System.IntPtr,System.Net.EndPoint,System.Net.EndPoint)">
+            <summary>
+            Initializes a RioSocketWrapper instance for an accepted socket.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioSocketWrapper.Finalize">
+            <summary>
+            Finalizer
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.RioSocketWrapper.HasData">
+            <summary>
+            Indicates whether there are data that has been received from the network and is available to be read.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.RioSocketWrapper.LocalEndPoint">
+            <summary>
+            Returns the local endpoint.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.RioSocketWrapper.RemoteEndPoint">
+            <summary>
+            Returns the remote endpoint
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.RioSocketWrapper.SockHandle">
+            <summary>
+            Returns the handle of native socket.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioSocketWrapper.Accept">
+            <summary>
+            Accepts a incoming connection request.
+            </summary>
+            <returns>A ISocket instance used to send and receive data</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioSocketWrapper.Close">
+            <summary>
+            Close the ISocket connections and releases all associated resources.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioSocketWrapper.Connect(System.Net.IPAddress,System.Int32)">
+            <summary>
+            Establishes a connection to a remote host that is specified by an IP address and a port number
+            </summary>
+            <param name="remoteaddr">The IP address of the remote host</param>
+            <param name="port">The port number of the remote host</param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioSocketWrapper.Dispose">
+            <summary>
+            Releases all resources used by the current instance of the RioSocketWrapper class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioSocketWrapper.GetStream">
+            <summary>
+            Returns a stream used to send and receive data.
+            </summary>
+            <returns>The underlying Stream instance that be used to send and receive data</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioSocketWrapper.Listen(System.Int32)">
+            <summary>
+            Starts listening for incoming connections requests
+            </summary>
+            <param name="backlog">The maximum length of the pending connections queue. </param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioSocketWrapper.Receive">
+            <summary>
+            Receives network data from this socket, and returns a ByteBuf that contains the received data.
+            </summary>
+            <returns>A ByteBuf object that contains received data.</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioSocketWrapper.Send(Microsoft.Spark.CSharp.Network.ByteBuf)">
+            <summary>
+            Sends data to this socket with a ByteBuf object that contains data to be sent.
+            </summary>
+            <param name="data">A ByteBuf object that contains data to be sent</param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioSocketWrapper.IoCompleted(System.Int64,System.Int32,System.UInt32)">
+            <summary>
+            IO completion callback
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioSocketWrapper.AllocateRequest">
+            <summary>
+            Allocates a room form request queue for this next IO.
+            </summary>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioSocketWrapper.CreateRequestQueue">
+            <summary>
+            Creates a request queue for this socket operation
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioSocketWrapper.DoReceive">
+            <summary>
+            Posts a receive operation to this socket
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioSocketWrapper.ProcessReceive(Microsoft.Spark.CSharp.Network.RequestContext,System.Int32,System.UInt32)">
+            <summary>
+            This method is invoked by the IoCompleted method to process the receive completion.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioSocketWrapper.DoSend(System.Int64,Microsoft.Spark.CSharp.Network.RequestContext)">
+            <summary>
+            Posts a send operation to this socket.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioSocketWrapper.ProcessSend(System.Int64,Microsoft.Spark.CSharp.Network.RequestContext,System.Int32,System.UInt32)">
+            <summary>
+            This method is invoked by the IoCompleted method to process the send completion.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioSocketWrapper.ReleaseRequest">
+            <summary>
+            Release room back to request queue.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioSocketWrapper.GenerateUniqueKey">
+            <summary>
+            Generates a unique key from a GUID.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper">
+            <summary>
+            SaeaSocketWrapper class is a wrapper of a socket that use SocketAsyncEventArgs class
+            to implement socket operations.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.#ctor">
+            <summary>
+            Default ctor that creates a new instance of SaeaSocketWrapper class.
+            The instance binds to loop-back address with port 0.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.#ctor(Microsoft.Spark.CSharp.Network.SaeaSocketWrapper,System.Net.Sockets.Socket)">
+            <summary>
+            Initializes a SaeaSocketWrapper instance for an accepted socket.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.Finalize">
+            <summary>
+            Finalizer.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.HasData">
+            <summary>
+            Indicates whether there are data that has been received from the network and is available to be read.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.LocalEndPoint">
+            <summary>
+            Returns the local endpoint.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.RemoteEndPoint">
+            <summary>
+            Returns the remote endpoint
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.Accept">
+            <summary>
+            Accepts a incoming connection request.
+            </summary>
+            <returns>A ISocket instance used to send and receive data</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.Close">
+            <summary>
+            Close the ISocket connections and releases all associated resources.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.Connect(System.Net.IPAddress,System.Int32)">
+            <summary>
+            Establishes a connection to a remote host that is specified by an IP address and a port number
+            </summary>
+            <param name="remoteaddr">The IP address of the remote host</param>
+            <param name="port">The port number of the remote host</param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.Dispose">
+            <summary>
+            Releases all resources used by the current instance of the SaeaSocketWrapper class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.GetStream">
+            <summary>
+            Returns a stream used to send and receive data.
+            </summary>
+            <returns>The underlying Stream instance that be used to send and receive data</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.Listen(System.Int32)">
+            <summary>
+            Starts listening for incoming connections requests
+            </summary>
+            <param name="backlog">The maximum length of the pending connections queue. </param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.Receive">
+            <summary>
+            Receives network data from this socket, and returns a ByteBuf that contains the received data.
+            </summary>
+            <returns>A ByteBuf object that contains received data.</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.Send(Microsoft.Spark.CSharp.Network.ByteBuf)">
+            <summary>
+            Sends data to this socket with a ByteBuf object that contains data to be sent.
+            </summary>
+            <param name="data">A ByteBuf object that contains data to be sent</param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.Dispose(System.Boolean)">
+            <summary>
+            Implementation of the Dispose pattern.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.IoCompleted(System.Object,System.Net.Sockets.SocketAsyncEventArgs)">
+            <summary>
+            The callback is called whenever a receive or send operation completes. However,
+            it is not be called if the receive/send operation completes synchronously.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.DoReceive(Microsoft.Spark.CSharp.Network.SaeaSocketWrapper)">
+            <summary>
+            Post a receive operation
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.ProcessReceive(System.Net.Sockets.SocketAsyncEventArgs)">
+            <summary>
+            This method is invoked by the IoCompleted method when an asynchronous receive
+            operation completes. If the remote host closed the connection, then the socket
+            is closed. Otherwise, we process the received data.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.DoSend(Microsoft.Spark.CSharp.Network.SockDataToken)">
+            <summary>
+            Posts a send operation with a SockDataToken which contains the data to be sent.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.DoSend(System.Net.Sockets.SocketAsyncEventArgs)">
+            <summary>
+            Posts a send operation with a send EventArgs
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.ProcessSend(System.Net.Sockets.SocketAsyncEventArgs)">
+            <summary>
+            This method is called by IoCompleted() when an asynchronous send completes.  
+            If all of the data has NOT been sent, then it calls PostSend to send more data. 
+            </summary>
+        </member>
+        <member name="T:Microsoft.Spark.CSharp.Network.SocketStream">
+            <summary>
+            Provides the underlying stream of data for network access.
+            Just like a NetworkStream.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SocketStream.#ctor(Microsoft.Spark.CSharp.Network.SaeaSocketWrapper)">
+            <summary>
+            Initializes a SocketStream with a SaeaSocketWrapper object.
+            </summary>
+            <param name="socket">a SaeaSocketWrapper object</param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SocketStream.#ctor(Microsoft.Spark.CSharp.Network.RioSocketWrapper)">
+            <summary>
+            Initializes a SocketStream with a RioSocketWrapper object.
+            </summary>
+            <param name="socket">a RioSocketWrapper object</param>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.SocketStream.CanRead">
+            <summary>
+            Indicates that data can be read from the stream.
+            This property always returns <see langword='true'/>
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.SocketStream.CanSeek">
+            <summary>
+            Indicates that the stream can seek a specific location in the stream.
+            This property always returns <see langword='false'/>
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.SocketStream.CanWrite">
+            <summary>
+            Indicates that data can be written to the stream.
+            This property always returns <see langword='true'/>
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.SocketStream.Length">
+            <summary>
+            The length of data available on the stream.
+            Always throws <see cref='T:System.NotSupportedException'/>.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.SocketStream.Position">
+            <summary>
+            Gets or sets the position in the stream.
+            Always throws <see cref='T:System.NotSupportedException'/>.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SocketStream.Flush">
+            <summary>
+            Flushes data from the stream.  This is meaningless for us, so it does nothing.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SocketStream.Seek(System.Int64,System.IO.SeekOrigin)">
+            <summary>
+            Seeks a specific position in the stream. This method is not supported
+            by the SocketDataStream class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SocketStream.SetLength(System.Int64)">
+            <summary>
+            Sets the length of the stream. This method is not supported by the SocketDataStream class.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SocketStream.ReadByte">
+            <summary>
+            Reads a byte from the stream and advances the position within the stream by one byte, or returns -1 if at the end of the stream.
+            </summary>
+            <returns>
+            The unsigned byte cast to an Int32, or -1 if at the end of the stream.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SocketStream.Read(System.Byte[],System.Int32,System.Int32)">
+            <summary>
+            Reads data from the stream.
+            </summary>
+            <param name="buffer">Buffer to read into.</param>
+            <param name="offset">Offset into the buffer where we're to read.</param>
+            <param name="count">Number of bytes to read.</param>
+            <returns>Number of bytes we read.</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SocketStream.Write(System.Byte[],System.Int32,System.Int32)">
+            <summary>
+            Writes data to the stream.
+            </summary>
+            <param name="buffer">Buffer to write from.</param>
+            <param name="offset">Offset into the buffer from where we'll start writing.</param>
+            <param name="count">Number of bytes to write.</param>
+        </member>
+        <member name="T:Microsoft.Spark.CSharp.Network.SockDataToken">
+            <summary>
+            SockDataToken class is used to associate with the SocketAsyncEventArgs object.
+            Primarily, it is a way to pass state to the event handler.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SockDataToken.#ctor(Microsoft.Spark.CSharp.Network.SaeaSocketWrapper,Microsoft.Spark.CSharp.Network.ByteBuf)">
+            <summary>
+            Initializes a SockDataToken instance with a client socket and a dataBuf 
+            </summary>
+            <param name="clientSocket">The client socket</param>
+            <param name="dataBuf">A data buffer that holds the data</param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SockDataToken.Reset">
+            <summary>
+            Reset this token
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SockDataToken.DetachData">
+            <summary>
+            Detach the data ownership.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.SockDataToken.Data">
+            <summary>
+            Gets and sets the data
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.SockDataToken.ClientSocket">
+            <summary>
+            Gets and sets the client socket.
             </summary>
         </member>
         <member name="T:Microsoft.Spark.CSharp.Network.SocketFactory">
@@ -3002,6 +3958,11 @@
             
             The ISocket instance can be RioSocket object, if the configuration is set to RioSocket and
             only the application is running on a Windows OS that supports Registered IO socket.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Network.SocketFactory.SocketWrapperType">
+            <summary>
+            Set socket wrapper type only for internal use (unit test)
             </summary>
         </member>
         <member name="M:Microsoft.Spark.CSharp.Network.SocketFactory.CreateSocket">
@@ -3013,6 +3974,36 @@
             is running on a Window OS that supports Registered IO socket. By default, it returns
             DefaultSocket instance which wraps System.Net.Sockets.Socket.
             </returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SocketFactory.IsRioSockSupported">
+            <summary>
+            Indicates whether current OS supports RIO socket.
+            </summary>
+        </member>
+        <member name="T:Microsoft.Spark.CSharp.Network.SocketWrapperType">
+            <summary>
+            SocketWrapperType defines the socket wrapper type be used in transport.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Spark.CSharp.Network.SocketWrapperType.None">
+            <summary>
+            None
+            </summary>
+        </member>
+        <member name="F:Microsoft.Spark.CSharp.Network.SocketWrapperType.Normal">
+            <summary>
+            Indicates CSharp code use System.Net.Sockets.Socket as transport
+            </summary>
+        </member>
+        <member name="F:Microsoft.Spark.CSharp.Network.SocketWrapperType.Rio">
+            <summary>
+            Indicates CSharp code use Windows RIO socket as transport
+            </summary>
+        </member>
+        <member name="F:Microsoft.Spark.CSharp.Network.SocketWrapperType.Saea">
+            <summary>
+            Indicates CSharp code use System.Net.Sockets.Socket with SocketAsyncEventArgs as transport
+            </summary>
         </member>
         <member name="M:Microsoft.Spark.CSharp.Proxy.Ipc.DataFrameIpcProxy.Intersect(Microsoft.Spark.CSharp.Proxy.IDataFrameProxy)">
             <summary>
@@ -3176,6 +4167,84 @@
             Right now it just prints out the messages to Console
             </summary>
         </member>
+        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.GetLoggerInstance(System.Type)">
+            <summary>
+            Get an instance of ILoggerService by a given type of logger
+            </summary>
+            <param name="type">The type of a logger to return</param>
+            <returns>An instance of ILoggerService</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.LogDebug(System.String)">
+            <summary>
+            Logs a message at debug level.
+            </summary>
+            <param name="message">The message to be logged</param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.LogDebug(System.String,System.Object[])">
+            <summary>
+            Logs a message at debug level with a format string.
+            </summary>
+            <param name="messageFormat">The format string</param>
+            <param name="messageParameters">The array of arguments</param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.LogInfo(System.String)">
+            <summary>
+            Logs a message at info level.
+            </summary>
+            <param name="message">The message to be logged</param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.LogInfo(System.String,System.Object[])">
+            <summary>
+            Logs a message at info level with a format string.
+            </summary>
+            <param name="messageFormat">The format string</param>
+            <param name="messageParameters">The array of arguments</param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.LogWarn(System.String)">
+            <summary>
+            Logs a message at warning level.
+            </summary>
+            <param name="message">The message to be logged</param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.LogWarn(System.String,System.Object[])">
+            <summary>
+            Logs a message at warning level with a format string.
+            </summary>
+            <param name="messageFormat">The format string</param>
+            <param name="messageParameters">The array of arguments</param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.LogFatal(System.String)">
+            <summary>
+            Logs a fatal message.
+            </summary>
+            <param name="message">The message to be logged</param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.LogFatal(System.String,System.Object[])">
+            <summary>
+            Logs a fatal message with a format string.
+            </summary>
+            <param name="messageFormat">The format string</param>
+            <param name="messageParameters">The array of arguments</param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.LogError(System.String)">
+            <summary>
+            Logs a error message.
+            </summary>
+            <param name="message">The message to be logged</param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.LogError(System.String,System.Object[])">
+            <summary>
+            Logs a error message with a format string.
+            </summary>
+            <param name="messageFormat">The format string</param>
+            <param name="messageParameters">The array of arguments</param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.LogException(System.Exception)">
+            <summary>
+            Logs an exception
+            </summary>
+            <param name="e">The exception to be logged</param>
+        </member>
         <member name="T:Microsoft.Spark.CSharp.Services.ILoggerService">
             <summary>
             Defines a logger what be used in service
@@ -3254,84 +4323,6 @@
             <param name="messageParameters">The array of arguments</param>
         </member>
         <member name="M:Microsoft.Spark.CSharp.Services.ILoggerService.LogException(System.Exception)">
-            <summary>
-            Logs an exception
-            </summary>
-            <param name="e">The exception to be logged</param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.GetLoggerInstance(System.Type)">
-            <summary>
-            Get an instance of ILoggerService by a given type of logger
-            </summary>
-            <param name="type">The type of a logger to return</param>
-            <returns>An instance of ILoggerService</returns>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.LogDebug(System.String)">
-            <summary>
-            Logs a message at debug level.
-            </summary>
-            <param name="message">The message to be logged</param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.LogDebug(System.String,System.Object[])">
-            <summary>
-            Logs a message at debug level with a format string.
-            </summary>
-            <param name="messageFormat">The format string</param>
-            <param name="messageParameters">The array of arguments</param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.LogInfo(System.String)">
-            <summary>
-            Logs a message at info level.
-            </summary>
-            <param name="message">The message to be logged</param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.LogInfo(System.String,System.Object[])">
-            <summary>
-            Logs a message at info level with a format string.
-            </summary>
-            <param name="messageFormat">The format string</param>
-            <param name="messageParameters">The array of arguments</param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.LogWarn(System.String)">
-            <summary>
-            Logs a message at warning level.
-            </summary>
-            <param name="message">The message to be logged</param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.LogWarn(System.String,System.Object[])">
-            <summary>
-            Logs a message at warning level with a format string.
-            </summary>
-            <param name="messageFormat">The format string</param>
-            <param name="messageParameters">The array of arguments</param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.LogFatal(System.String)">
-            <summary>
-            Logs a fatal message.
-            </summary>
-            <param name="message">The message to be logged</param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.LogFatal(System.String,System.Object[])">
-            <summary>
-            Logs a fatal message with a format string.
-            </summary>
-            <param name="messageFormat">The format string</param>
-            <param name="messageParameters">The array of arguments</param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.LogError(System.String)">
-            <summary>
-            Logs a error message.
-            </summary>
-            <param name="message">The message to be logged</param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.LogError(System.String,System.Object[])">
-            <summary>
-            Logs a error message with a format string.
-            </summary>
-            <param name="messageFormat">The format string</param>
-            <param name="messageParameters">The array of arguments</param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.LogException(System.Exception)">
             <summary>
             Logs an exception
             </summary>
@@ -3667,6 +4658,27 @@
             
             See also http://spark.apache.org/docs/latest/api/scala/index.html#org.apache.spark.sql.DataFrame
             </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Sql.DataFrame.Rdd">
+            <summary>
+            Represents the content of the DataFrame as an RDD of Rows.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Sql.DataFrame.IsLocal">
+            <summary>
+            Returns true if the collect and take methods can be run locally (without any Spark executors).
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Sql.DataFrame.Schema">
+            <summary>
+            Returns the schema of this DataFrame.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Sql.DataFrame.Item(System.String)">
+            <summary>
+            Returns a column for a given column name.
+            </summary>
+            <param name="columnName">The name of column</param>
         </member>
         <member name="M:Microsoft.Spark.CSharp.Sql.DataFrame.RegisterTempTable(System.String)">
             <summary>
@@ -4223,27 +5235,6 @@
             SaveMode specified by mode, and a set of options.
             </summary>
         </member>
-        <member name="P:Microsoft.Spark.CSharp.Sql.DataFrame.Rdd">
-            <summary>
-            Represents the content of the DataFrame as an RDD of Rows.
-            </summary>
-        </member>
-        <member name="P:Microsoft.Spark.CSharp.Sql.DataFrame.IsLocal">
-            <summary>
-            Returns true if the collect and take methods can be run locally (without any Spark executors).
-            </summary>
-        </member>
-        <member name="P:Microsoft.Spark.CSharp.Sql.DataFrame.Schema">
-            <summary>
-            Returns the schema of this DataFrame.
-            </summary>
-        </member>
-        <member name="P:Microsoft.Spark.CSharp.Sql.DataFrame.Item(System.String)">
-            <summary>
-            Returns a column for a given column name.
-            </summary>
-            <param name="columnName">The name of column</param>
-        </member>
         <member name="T:Microsoft.Spark.CSharp.Sql.JoinType">
             <summary>
             The type of join operation for DataFrame
@@ -4663,341 +5654,6 @@
             Configuration for Hive is read from hive-site.xml on the classpath.
             It supports running both SQL and HiveQL commands.
             </summary>
-        </member>
-        <member name="T:Microsoft.Spark.CSharp.Sql.SqlContext">
-            <summary>
-            The entry point for working with structured data (rows and columns) in Spark.  
-            Allows the creation of [[DataFrame]] objects as well as the execution of SQL queries.
-            </summary>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.#ctor(Microsoft.Spark.CSharp.Core.SparkContext)">
-            <summary>
-            Creates a SqlContext
-            </summary>
-            <param name="sparkContext"></param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.GetOrCreate(Microsoft.Spark.CSharp.Core.SparkContext)">
-            <summary>
-            Get the existing SQLContext or create a new one with given SparkContext.
-            </summary>
-            <param name="sparkContext"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.NewSession">
-            <summary>
-            Returns a new SQLContext as new session, that has separate SQLConf, 
-            registered temporary tables and UDFs, but shared SparkContext and table cache.
-            </summary>
-            <returns></returns>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.GetConf(System.String,System.String)">
-            <summary>
-            Returns the value of Spark SQL configuration property for the given key.
-            If the key is not set, returns defaultValue.
-            </summary>
-            <param name="key"></param>
-            <param name="defaultValue"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.SetConf(System.String,System.String)">
-            <summary>
-            Sets the given Spark SQL configuration property.
-            </summary>
-            <param name="key"></param>
-            <param name="value"></param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.Read">
-            <summary>
-            Returns a DataFrameReader that can be used to read data in as a DataFrame.
-            </summary>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.ReadDataFrame(System.String,Microsoft.Spark.CSharp.Sql.StructType,System.Collections.Generic.Dictionary{System.String,System.String})">
-            <summary>
-            Loads a dataframe the source path using the given schema and options
-            </summary>
-            <param name="path"></param>
-            <param name="schema"></param>
-            <param name="options"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.CreateDataFrame(Microsoft.Spark.CSharp.Core.RDD{System.Object[]},Microsoft.Spark.CSharp.Sql.StructType)">
-            <summary>
-            Creates a <see cref="T:Microsoft.Spark.CSharp.Sql.DataFrame"/> from a RDD containing array of object using the given schema.
-            </summary>
-            <param name="rdd">RDD containing array of object. The array acts as a row and items within the array act as columns which the schema is specified in <paramref name="schema"/>. </param>
-            <param name="schema">The schema of DataFrame.</param>
-            <returns></returns>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterDataFrameAsTable(Microsoft.Spark.CSharp.Sql.DataFrame,System.String)">
-            <summary>
-            Registers the given <see cref="T:Microsoft.Spark.CSharp.Sql.DataFrame"/> as a temporary table in the catalog.
-            Temporary tables exist only during the lifetime of this instance of SqlContext.
-            </summary>
-            <param name="dataFrame"></param>
-            <param name="tableName"></param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.DropTempTable(System.String)">
-            <summary>
-            Remove the temp table from catalog.
-            </summary>
-            <param name="tableName"></param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.Table(System.String)">
-            <summary>
-            Returns the specified table as a <see cref="T:Microsoft.Spark.CSharp.Sql.DataFrame"/>
-            </summary>
-            <param name="tableName"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.Tables(System.String)">
-            <summary>
-            Returns a <see cref="T:Microsoft.Spark.CSharp.Sql.DataFrame"/> containing names of tables in the given database.
-            If <paramref name="databaseName"/> is not specified, the current database will be used.
-            The returned DataFrame has two columns: 'tableName' and 'isTemporary' (a column with bool 
-            type indicating if a table is a temporary one or not).
-            </summary>
-            <param name="databaseName">Name of the database to use. Default to the current database. 
-            Note: This is only applicable to HiveContext.</param>
-            <returns></returns>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.TableNames(System.String)">
-            <summary>
-            Returns a list of names of tables in the database <paramref name="databaseName"/>
-            </summary>
-            <param name="databaseName">Name of the database to use. Default to the current database.
-            Note: This is only applicable to HiveContext.</param>
-            <returns></returns>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.CacheTable(System.String)">
-            <summary>
-            Caches the specified table in-memory.
-            </summary>
-            <param name="tableName"></param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.UncacheTable(System.String)">
-            <summary>
-            Removes the specified table from the in-memory cache.
-            </summary>
-            <param name="tableName"></param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.ClearCache">
-            <summary>
-            Removes all cached tables from the in-memory cache.
-            </summary>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.IsCached(System.String)">
-            <summary>
-            Returns true if the table is currently cached in-memory.
-            </summary>
-            <param name="tableName"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.Sql(System.String)">
-            <summary>
-            Executes a SQL query using Spark, returning the result as a DataFrame. The dialect that is used for SQL parsing can be configured with 'spark.sql.dialect'
-            </summary>
-            <param name="sqlQuery"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.JsonFile(System.String)">
-            <summary>
-            Loads a JSON file (one object per line), returning the result as a DataFrame
-            It goes through the entire dataset once to determine the schema.
-            </summary>
-            <param name="path">path to JSON file</param>
-            <returns></returns>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.JsonFile(System.String,Microsoft.Spark.CSharp.Sql.StructType)">
-            <summary>
-            Loads a JSON file (one object per line) and applies the given schema
-            </summary>
-            <param name="path">path to JSON file</param>
-            <param name="schema">schema to use</param>
-            <returns></returns>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.TextFile(System.String,Microsoft.Spark.CSharp.Sql.StructType,System.String)">
-            <summary>
-            Loads text file with the specific column delimited using the given schema
-            </summary>
-            <param name="path">path to text file</param>
-            <param name="schema">schema to use</param>
-            <param name="delimiter">delimiter to use</param>
-            <returns></returns>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.TextFile(System.String,System.String,System.Boolean,System.Boolean)">
-            <summary>
-            Loads a text file (one object per line), returning the result as a DataFrame
-            </summary>
-            <param name="path">path to text file</param>
-            <param name="delimiter">delimited to use</param>
-            <param name="hasHeader">indicates if the text file has a header row</param>
-            <param name="inferSchema">indicates if every row has to be read to infer the schema; if false, columns will be strings</param>
-            <returns></returns>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterFunction``1(System.String,System.Func{``0})">
-            <summary>
-            Register UDF with no input argument, e.g:
-                SqlContext.RegisterFunction&lt;bool>("MyFilter", () => true);
-                sqlContext.Sql("SELECT * FROM MyTable where MyFilter()");
-            </summary>
-            <typeparam name="RT"></typeparam>
-            <param name="name"></param>
-            <param name="f"></param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterFunction``2(System.String,System.Func{``1,``0})">
-            <summary>
-            Register UDF with 1 input argument, e.g:
-                SqlContext.RegisterFunction&lt;bool, string>("MyFilter", (arg1) => arg1 != null);
-                sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1)");
-            </summary>
-            <typeparam name="RT"></typeparam>
-            <typeparam name="A1"></typeparam>
-            <param name="name"></param>
-            <param name="f"></param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterFunction``3(System.String,System.Func{``1,``2,``0})">
-            <summary>
-            Register UDF with 2 input arguments, e.g:
-                SqlContext.RegisterFunction&lt;bool, string, string>("MyFilter", (arg1, arg2) => arg1 != null &amp;&amp; arg2 != null);
-                sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2)");
-            </summary>
-            <typeparam name="RT"></typeparam>
-            <typeparam name="A1"></typeparam>
-            <typeparam name="A2"></typeparam>
-            <param name="name"></param>
-            <param name="f"></param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterFunction``4(System.String,System.Func{``1,``2,``3,``0})">
-            <summary>
-            Register UDF with 3 input arguments, e.g:
-                SqlContext.RegisterFunction&lt;bool, string, string, string>("MyFilter", (arg1, arg2, arg3) => arg1 != null &amp;&amp; arg2 != null &amp;&amp; arg3 != null);
-                sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, columnName3)");
-            </summary>
-            <typeparam name="RT"></typeparam>
-            <typeparam name="A1"></typeparam>
-            <typeparam name="A2"></typeparam>
-            <typeparam name="A3"></typeparam>
-            <param name="name"></param>
-            <param name="f"></param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterFunction``5(System.String,System.Func{``1,``2,``3,``4,``0})">
-            <summary>
-            Register UDF with 4 input arguments, e.g:
-                SqlContext.RegisterFunction&lt;bool, string, string, ..., string>("MyFilter", (arg1, arg2, ..., arg4) => arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg3 != null);
-                sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName4)");
-            </summary>
-            <typeparam name="RT"></typeparam>
-            <typeparam name="A1"></typeparam>
-            <typeparam name="A2"></typeparam>
-            <typeparam name="A3"></typeparam>
-            <typeparam name="A4"></typeparam>
-            <param name="name"></param>
-            <param name="f"></param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterFunction``6(System.String,System.Func{``1,``2,``3,``4,``5,``0})">
-            <summary>
-            Register UDF with 5 input arguments, e.g:
-                SqlContext.RegisterFunction&lt;bool, string, string, ..., string>("MyFilter", (arg1, arg2, ..., arg5) => arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg5 != null);
-                sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName5)");
-            </summary>
-            <typeparam name="RT"></typeparam>
-            <typeparam name="A1"></typeparam>
-            <typeparam name="A2"></typeparam>
-            <typeparam name="A3"></typeparam>
-            <typeparam name="A4"></typeparam>
-            <typeparam name="A5"></typeparam>
-            <param name="name"></param>
-            <param name="f"></param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterFunction``7(System.String,System.Func{``1,``2,``3,``4,``5,``6,``0})">
-            <summary>
-            Register UDF with 6 input arguments, e.g:
-                SqlContext.RegisterFunction&lt;bool, string, string, ..., string>("MyFilter", (arg1, arg2, ..., arg6) => arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg6 != null);
-                sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName6)");
-            </summary>
-            <typeparam name="RT"></typeparam>
-            <typeparam name="A1"></typeparam>
-            <typeparam name="A2"></typeparam>
-            <typeparam name="A3"></typeparam>
-            <typeparam name="A4"></typeparam>
-            <typeparam name="A5"></typeparam>
-            <typeparam name="A6"></typeparam>
-            <param name="name"></param>
-            <param name="f"></param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterFunction``8(System.String,System.Func{``1,``2,``3,``4,``5,``6,``7,``0})">
-            <summary>
-            Register UDF with 7 input arguments, e.g:
-                SqlContext.RegisterFunction&lt;bool, string, string, ..., string>("MyFilter", (arg1, arg2, ..., arg7) => arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg7 != null);
-                sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName7)");
-            </summary>
-            <typeparam name="RT"></typeparam>
-            <typeparam name="A1"></typeparam>
-            <typeparam name="A2"></typeparam>
-            <typeparam name="A3"></typeparam>
-            <typeparam name="A4"></typeparam>
-            <typeparam name="A5"></typeparam>
-            <typeparam name="A6"></typeparam>
-            <typeparam name="A7"></typeparam>
-            <param name="name"></param>
-            <param name="f"></param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterFunction``9(System.String,System.Func{``1,``2,``3,``4,``5,``6,``7,``8,``0})">
-            <summary>
-            Register UDF with 8 input arguments, e.g:
-                SqlContext.RegisterFunction&lt;bool, string, string, ..., string>("MyFilter", (arg1, arg2, ..., arg8) => arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg8 != null);
-                sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName8)");
-            </summary>
-            <typeparam name="RT"></typeparam>
-            <typeparam name="A1"></typeparam>
-            <typeparam name="A2"></typeparam>
-            <typeparam name="A3"></typeparam>
-            <typeparam name="A4"></typeparam>
-            <typeparam name="A5"></typeparam>
-            <typeparam name="A6"></typeparam>
-            <typeparam name="A7"></typeparam>
-            <typeparam name="A8"></typeparam>
-            <param name="name"></param>
-            <param name="f"></param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterFunction``10(System.String,System.Func{``1,``2,``3,``4,``5,``6,``7,``8,``9,``0})">
-            <summary>
-            Register UDF with 9 input arguments, e.g:
-                SqlContext.RegisterFunction&lt;bool, string, string, ..., string>("MyFilter", (arg1, arg2, ..., arg9) => arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg9 != null);
-                sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName9)");
-            </summary>
-            <typeparam name="RT"></typeparam>
-            <typeparam name="A1"></typeparam>
-            <typeparam name="A2"></typeparam>
-            <typeparam name="A3"></typeparam>
-            <typeparam name="A4"></typeparam>
-            <typeparam name="A5"></typeparam>
-            <typeparam name="A6"></typeparam>
-            <typeparam name="A7"></typeparam>
-            <typeparam name="A8"></typeparam>
-            <typeparam name="A9"></typeparam>
-            <param name="name"></param>
-            <param name="f"></param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterFunction``11(System.String,System.Func{``1,``2,``3,``4,``5,``6,``7,``8,``9,``10,``0})">
-            <summary>
-            Register UDF with 10 input arguments, e.g:
-                SqlContext.RegisterFunction&lt;bool, string, string, ..., string>("MyFilter", (arg1, arg2, ..., arg10) => arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg10 != null);
-                sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName10)");
-            </summary>
-            <typeparam name="RT"></typeparam>
-            <typeparam name="A1"></typeparam>
-            <typeparam name="A2"></typeparam>
-            <typeparam name="A3"></typeparam>
-            <typeparam name="A4"></typeparam>
-            <typeparam name="A5"></typeparam>
-            <typeparam name="A6"></typeparam>
-            <typeparam name="A7"></typeparam>
-            <typeparam name="A8"></typeparam>
-            <typeparam name="A9"></typeparam>
-            <typeparam name="A10"></typeparam>
-            <param name="name"></param>
-            <param name="f"></param>
         </member>
         <member name="M:Microsoft.Spark.CSharp.Sql.HiveContext.#ctor(Microsoft.Spark.CSharp.Core.SparkContext)">
             <summary>
@@ -5801,26 +6457,345 @@
             <param name="mode">The given SaveMode</param>
             <returns>The string that represents the given SaveMode</returns>
         </member>
+        <member name="T:Microsoft.Spark.CSharp.Sql.SqlContext">
+            <summary>
+            The entry point for working with structured data (rows and columns) in Spark.  
+            Allows the creation of [[DataFrame]] objects as well as the execution of SQL queries.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.#ctor(Microsoft.Spark.CSharp.Core.SparkContext)">
+            <summary>
+            Creates a SqlContext
+            </summary>
+            <param name="sparkContext"></param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.GetOrCreate(Microsoft.Spark.CSharp.Core.SparkContext)">
+            <summary>
+            Get the existing SQLContext or create a new one with given SparkContext.
+            </summary>
+            <param name="sparkContext"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.NewSession">
+            <summary>
+            Returns a new SQLContext as new session, that has separate SQLConf, 
+            registered temporary tables and UDFs, but shared SparkContext and table cache.
+            </summary>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.GetConf(System.String,System.String)">
+            <summary>
+            Returns the value of Spark SQL configuration property for the given key.
+            If the key is not set, returns defaultValue.
+            </summary>
+            <param name="key"></param>
+            <param name="defaultValue"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.SetConf(System.String,System.String)">
+            <summary>
+            Sets the given Spark SQL configuration property.
+            </summary>
+            <param name="key"></param>
+            <param name="value"></param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.Read">
+            <summary>
+            Returns a DataFrameReader that can be used to read data in as a DataFrame.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.ReadDataFrame(System.String,Microsoft.Spark.CSharp.Sql.StructType,System.Collections.Generic.Dictionary{System.String,System.String})">
+            <summary>
+            Loads a dataframe the source path using the given schema and options
+            </summary>
+            <param name="path"></param>
+            <param name="schema"></param>
+            <param name="options"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.CreateDataFrame(Microsoft.Spark.CSharp.Core.RDD{System.Object[]},Microsoft.Spark.CSharp.Sql.StructType)">
+            <summary>
+            Creates a <see cref="T:Microsoft.Spark.CSharp.Sql.DataFrame"/> from a RDD containing array of object using the given schema.
+            </summary>
+            <param name="rdd">RDD containing array of object. The array acts as a row and items within the array act as columns which the schema is specified in <paramref name="schema"/>. </param>
+            <param name="schema">The schema of DataFrame.</param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterDataFrameAsTable(Microsoft.Spark.CSharp.Sql.DataFrame,System.String)">
+            <summary>
+            Registers the given <see cref="T:Microsoft.Spark.CSharp.Sql.DataFrame"/> as a temporary table in the catalog.
+            Temporary tables exist only during the lifetime of this instance of SqlContext.
+            </summary>
+            <param name="dataFrame"></param>
+            <param name="tableName"></param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.DropTempTable(System.String)">
+            <summary>
+            Remove the temp table from catalog.
+            </summary>
+            <param name="tableName"></param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.Table(System.String)">
+            <summary>
+            Returns the specified table as a <see cref="T:Microsoft.Spark.CSharp.Sql.DataFrame"/>
+            </summary>
+            <param name="tableName"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.Tables(System.String)">
+            <summary>
+            Returns a <see cref="T:Microsoft.Spark.CSharp.Sql.DataFrame"/> containing names of tables in the given database.
+            If <paramref name="databaseName"/> is not specified, the current database will be used.
+            The returned DataFrame has two columns: 'tableName' and 'isTemporary' (a column with bool 
+            type indicating if a table is a temporary one or not).
+            </summary>
+            <param name="databaseName">Name of the database to use. Default to the current database. 
+            Note: This is only applicable to HiveContext.</param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.TableNames(System.String)">
+            <summary>
+            Returns a list of names of tables in the database <paramref name="databaseName"/>
+            </summary>
+            <param name="databaseName">Name of the database to use. Default to the current database.
+            Note: This is only applicable to HiveContext.</param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.CacheTable(System.String)">
+            <summary>
+            Caches the specified table in-memory.
+            </summary>
+            <param name="tableName"></param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.UncacheTable(System.String)">
+            <summary>
+            Removes the specified table from the in-memory cache.
+            </summary>
+            <param name="tableName"></param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.ClearCache">
+            <summary>
+            Removes all cached tables from the in-memory cache.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.IsCached(System.String)">
+            <summary>
+            Returns true if the table is currently cached in-memory.
+            </summary>
+            <param name="tableName"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.Sql(System.String)">
+            <summary>
+            Executes a SQL query using Spark, returning the result as a DataFrame. The dialect that is used for SQL parsing can be configured with 'spark.sql.dialect'
+            </summary>
+            <param name="sqlQuery"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.JsonFile(System.String)">
+            <summary>
+            Loads a JSON file (one object per line), returning the result as a DataFrame
+            It goes through the entire dataset once to determine the schema.
+            </summary>
+            <param name="path">path to JSON file</param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.JsonFile(System.String,Microsoft.Spark.CSharp.Sql.StructType)">
+            <summary>
+            Loads a JSON file (one object per line) and applies the given schema
+            </summary>
+            <param name="path">path to JSON file</param>
+            <param name="schema">schema to use</param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.TextFile(System.String,Microsoft.Spark.CSharp.Sql.StructType,System.String)">
+            <summary>
+            Loads text file with the specific column delimited using the given schema
+            </summary>
+            <param name="path">path to text file</param>
+            <param name="schema">schema to use</param>
+            <param name="delimiter">delimiter to use</param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.TextFile(System.String,System.String,System.Boolean,System.Boolean)">
+            <summary>
+            Loads a text file (one object per line), returning the result as a DataFrame
+            </summary>
+            <param name="path">path to text file</param>
+            <param name="delimiter">delimited to use</param>
+            <param name="hasHeader">indicates if the text file has a header row</param>
+            <param name="inferSchema">indicates if every row has to be read to infer the schema; if false, columns will be strings</param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterFunction``1(System.String,System.Func{``0})">
+            <summary>
+            Register UDF with no input argument, e.g:
+                SqlContext.RegisterFunction&lt;bool>("MyFilter", () => true);
+                sqlContext.Sql("SELECT * FROM MyTable where MyFilter()");
+            </summary>
+            <typeparam name="RT"></typeparam>
+            <param name="name"></param>
+            <param name="f"></param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterFunction``2(System.String,System.Func{``1,``0})">
+            <summary>
+            Register UDF with 1 input argument, e.g:
+                SqlContext.RegisterFunction&lt;bool, string>("MyFilter", (arg1) => arg1 != null);
+                sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1)");
+            </summary>
+            <typeparam name="RT"></typeparam>
+            <typeparam name="A1"></typeparam>
+            <param name="name"></param>
+            <param name="f"></param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterFunction``3(System.String,System.Func{``1,``2,``0})">
+            <summary>
+            Register UDF with 2 input arguments, e.g:
+                SqlContext.RegisterFunction&lt;bool, string, string>("MyFilter", (arg1, arg2) => arg1 != null &amp;&amp; arg2 != null);
+                sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2)");
+            </summary>
+            <typeparam name="RT"></typeparam>
+            <typeparam name="A1"></typeparam>
+            <typeparam name="A2"></typeparam>
+            <param name="name"></param>
+            <param name="f"></param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterFunction``4(System.String,System.Func{``1,``2,``3,``0})">
+            <summary>
+            Register UDF with 3 input arguments, e.g:
+                SqlContext.RegisterFunction&lt;bool, string, string, string>("MyFilter", (arg1, arg2, arg3) => arg1 != null &amp;&amp; arg2 != null &amp;&amp; arg3 != null);
+                sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, columnName3)");
+            </summary>
+            <typeparam name="RT"></typeparam>
+            <typeparam name="A1"></typeparam>
+            <typeparam name="A2"></typeparam>
+            <typeparam name="A3"></typeparam>
+            <param name="name"></param>
+            <param name="f"></param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterFunction``5(System.String,System.Func{``1,``2,``3,``4,``0})">
+            <summary>
+            Register UDF with 4 input arguments, e.g:
+                SqlContext.RegisterFunction&lt;bool, string, string, ..., string>("MyFilter", (arg1, arg2, ..., arg4) => arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg3 != null);
+                sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName4)");
+            </summary>
+            <typeparam name="RT"></typeparam>
+            <typeparam name="A1"></typeparam>
+            <typeparam name="A2"></typeparam>
+            <typeparam name="A3"></typeparam>
+            <typeparam name="A4"></typeparam>
+            <param name="name"></param>
+            <param name="f"></param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterFunction``6(System.String,System.Func{``1,``2,``3,``4,``5,``0})">
+            <summary>
+            Register UDF with 5 input arguments, e.g:
+                SqlContext.RegisterFunction&lt;bool, string, string, ..., string>("MyFilter", (arg1, arg2, ..., arg5) => arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg5 != null);
+                sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName5)");
+            </summary>
+            <typeparam name="RT"></typeparam>
+            <typeparam name="A1"></typeparam>
+            <typeparam name="A2"></typeparam>
+            <typeparam name="A3"></typeparam>
+            <typeparam name="A4"></typeparam>
+            <typeparam name="A5"></typeparam>
+            <param name="name"></param>
+            <param name="f"></param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterFunction``7(System.String,System.Func{``1,``2,``3,``4,``5,``6,``0})">
+            <summary>
+            Register UDF with 6 input arguments, e.g:
+                SqlContext.RegisterFunction&lt;bool, string, string, ..., string>("MyFilter", (arg1, arg2, ..., arg6) => arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg6 != null);
+                sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName6)");
+            </summary>
+            <typeparam name="RT"></typeparam>
+            <typeparam name="A1"></typeparam>
+            <typeparam name="A2"></typeparam>
+            <typeparam name="A3"></typeparam>
+            <typeparam name="A4"></typeparam>
+            <typeparam name="A5"></typeparam>
+            <typeparam name="A6"></typeparam>
+            <param name="name"></param>
+            <param name="f"></param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterFunction``8(System.String,System.Func{``1,``2,``3,``4,``5,``6,``7,``0})">
+            <summary>
+            Register UDF with 7 input arguments, e.g:
+                SqlContext.RegisterFunction&lt;bool, string, string, ..., string>("MyFilter", (arg1, arg2, ..., arg7) => arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg7 != null);
+                sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName7)");
+            </summary>
+            <typeparam name="RT"></typeparam>
+            <typeparam name="A1"></typeparam>
+            <typeparam name="A2"></typeparam>
+            <typeparam name="A3"></typeparam>
+            <typeparam name="A4"></typeparam>
+            <typeparam name="A5"></typeparam>
+            <typeparam name="A6"></typeparam>
+            <typeparam name="A7"></typeparam>
+            <param name="name"></param>
+            <param name="f"></param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterFunction``9(System.String,System.Func{``1,``2,``3,``4,``5,``6,``7,``8,``0})">
+            <summary>
+            Register UDF with 8 input arguments, e.g:
+                SqlContext.RegisterFunction&lt;bool, string, string, ..., string>("MyFilter", (arg1, arg2, ..., arg8) => arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg8 != null);
+                sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName8)");
+            </summary>
+            <typeparam name="RT"></typeparam>
+            <typeparam name="A1"></typeparam>
+            <typeparam name="A2"></typeparam>
+            <typeparam name="A3"></typeparam>
+            <typeparam name="A4"></typeparam>
+            <typeparam name="A5"></typeparam>
+            <typeparam name="A6"></typeparam>
+            <typeparam name="A7"></typeparam>
+            <typeparam name="A8"></typeparam>
+            <param name="name"></param>
+            <param name="f"></param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterFunction``10(System.String,System.Func{``1,``2,``3,``4,``5,``6,``7,``8,``9,``0})">
+            <summary>
+            Register UDF with 9 input arguments, e.g:
+                SqlContext.RegisterFunction&lt;bool, string, string, ..., string>("MyFilter", (arg1, arg2, ..., arg9) => arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg9 != null);
+                sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName9)");
+            </summary>
+            <typeparam name="RT"></typeparam>
+            <typeparam name="A1"></typeparam>
+            <typeparam name="A2"></typeparam>
+            <typeparam name="A3"></typeparam>
+            <typeparam name="A4"></typeparam>
+            <typeparam name="A5"></typeparam>
+            <typeparam name="A6"></typeparam>
+            <typeparam name="A7"></typeparam>
+            <typeparam name="A8"></typeparam>
+            <typeparam name="A9"></typeparam>
+            <param name="name"></param>
+            <param name="f"></param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.RegisterFunction``11(System.String,System.Func{``1,``2,``3,``4,``5,``6,``7,``8,``9,``10,``0})">
+            <summary>
+            Register UDF with 10 input arguments, e.g:
+                SqlContext.RegisterFunction&lt;bool, string, string, ..., string>("MyFilter", (arg1, arg2, ..., arg10) => arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg10 != null);
+                sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName10)");
+            </summary>
+            <typeparam name="RT"></typeparam>
+            <typeparam name="A1"></typeparam>
+            <typeparam name="A2"></typeparam>
+            <typeparam name="A3"></typeparam>
+            <typeparam name="A4"></typeparam>
+            <typeparam name="A5"></typeparam>
+            <typeparam name="A6"></typeparam>
+            <typeparam name="A7"></typeparam>
+            <typeparam name="A8"></typeparam>
+            <typeparam name="A9"></typeparam>
+            <typeparam name="A10"></typeparam>
+            <param name="name"></param>
+            <param name="f"></param>
+        </member>
         <member name="T:Microsoft.Spark.CSharp.Sql.DataType">
             <summary>
             The base type of all Spark SQL data types.
             </summary>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.DataType.ParseDataTypeFromJson(System.String)">
-            <summary>
-            Parses a Json string to construct a DataType.
-            </summary>
-            <param name="json">The Json string to be parsed</param>
-            <returns>The new DataType instance from the Json string</returns>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.DataType.ParseDataTypeFromJson(Newtonsoft.Json.Linq.JToken)">
-            <summary>
-            Parse a JToken object to construct a DataType.
-            </summary>
-            <param name="json">The JToken object to be parsed</param>
-            <returns>The new DataType instance from the Json string</returns>
-            <exception cref="T:System.NotImplementedException">Not implemented for "udt" type</exception>
-            <exception cref="T:System.ArgumentException"></exception>
         </member>
         <member name="P:Microsoft.Spark.CSharp.Sql.DataType.TypeName">
             <summary>
@@ -5841,6 +6816,22 @@
             <summary>
             The compact JSON representation of this data type.
             </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.DataType.ParseDataTypeFromJson(System.String)">
+            <summary>
+            Parses a Json string to construct a DataType.
+            </summary>
+            <param name="json">The Json string to be parsed</param>
+            <returns>The new DataType instance from the Json string</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.DataType.ParseDataTypeFromJson(Newtonsoft.Json.Linq.JToken)">
+            <summary>
+            Parse a JToken object to construct a DataType.
+            </summary>
+            <param name="json">The JToken object to be parsed</param>
+            <returns>The new DataType instance from the Json string</returns>
+            <exception cref="T:System.NotImplementedException">Not implemented for "udt" type</exception>
+            <exception cref="T:System.ArgumentException"></exception>
         </member>
         <member name="T:Microsoft.Spark.CSharp.Sql.AtomicType">
             <summary>
@@ -5956,20 +6947,6 @@
             The data type for collections of multiple values. 
             </summary>
         </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.ArrayType.#ctor(Microsoft.Spark.CSharp.Sql.DataType,System.Boolean)">
-            <summary>
-            Initializes a ArrayType instance with a specific DataType and specifying if the array has null values.
-            </summary>
-            <param name="elementType">The data type of values</param>
-            <param name="containsNull">Indicates if values have null values</param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.ArrayType.FromJson(Newtonsoft.Json.Linq.JObject)">
-            <summary>
-            Constructs a ArrayType from a Json object
-            </summary>
-            <param name="json">The Json object used to construct a ArrayType</param>
-            <returns>A new ArrayType instance</returns>
-        </member>
         <member name="P:Microsoft.Spark.CSharp.Sql.ArrayType.ElementType">
             <summary>
             Gets the DataType of each element in the array
@@ -5980,10 +6957,24 @@
             Returns whether the array can contain null (None) values
             </summary>
         </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.ArrayType.#ctor(Microsoft.Spark.CSharp.Sql.DataType,System.Boolean)">
+            <summary>
+            Initializes a ArrayType instance with a specific DataType and specifying if the array has null values.
+            </summary>
+            <param name="elementType">The data type of values</param>
+            <param name="containsNull">Indicates if values have null values</param>
+        </member>
         <member name="P:Microsoft.Spark.CSharp.Sql.ArrayType.SimpleString">
             <summary>
             Readable string representation for the type.
             </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.ArrayType.FromJson(Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Constructs a ArrayType from a Json object
+            </summary>
+            <param name="json">The Json object used to construct a ArrayType</param>
+            <returns>A new ArrayType instance</returns>
         </member>
         <member name="T:Microsoft.Spark.CSharp.Sql.MapType">
             <summary>
@@ -6002,22 +6993,6 @@
             <summary>
             A field inside a StructType.
             </summary>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.StructField.#ctor(System.String,Microsoft.Spark.CSharp.Sql.DataType,System.Boolean,Newtonsoft.Json.Linq.JObject)">
-            <summary>
-            Initializes a StructField instance with a specific name, data type, nullable, and metadata
-            </summary>
-            <param name="name">The name of this field</param>
-            <param name="dataType">The data type of this field</param>
-            <param name="isNullable">Indicates if values of this field can be null values</param>
-            <param name="metadata">The metadata of this field</param>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Sql.StructField.FromJson(Newtonsoft.Json.Linq.JObject)">
-            <summary>
-            Constructs a StructField from a Json object
-            </summary>
-            <param name="json">The Json object used to construct a StructField</param>
-            <returns>A new StructField instance</returns>
         </member>
         <member name="P:Microsoft.Spark.CSharp.Sql.StructField.Name">
             <summary>
@@ -6039,15 +7014,36 @@
             The metadata of this field. The metadata should be preserved during transformation if the content of the column is not modified, e.g, in selection. 
             </summary>
         </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.StructField.#ctor(System.String,Microsoft.Spark.CSharp.Sql.DataType,System.Boolean,Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Initializes a StructField instance with a specific name, data type, nullable, and metadata
+            </summary>
+            <param name="name">The name of this field</param>
+            <param name="dataType">The data type of this field</param>
+            <param name="isNullable">Indicates if values of this field can be null values</param>
+            <param name="metadata">The metadata of this field</param>
+        </member>
         <member name="P:Microsoft.Spark.CSharp.Sql.StructField.SimpleString">
             <summary>
             Returns a readable string that represents the type.
             </summary>
         </member>
+        <member name="M:Microsoft.Spark.CSharp.Sql.StructField.FromJson(Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Constructs a StructField from a Json object
+            </summary>
+            <param name="json">The Json object used to construct a StructField</param>
+            <returns>A new StructField instance</returns>
+        </member>
         <member name="T:Microsoft.Spark.CSharp.Sql.StructType">
             <summary>
             Struct type, consisting of a list of StructField
             This is the data type representing a Row
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Sql.StructType.Fields">
+            <summary>
+            Gets a list of StructField.
             </summary>
         </member>
         <member name="M:Microsoft.Spark.CSharp.Sql.StructType.#ctor(System.Collections.Generic.IEnumerable{Microsoft.Spark.CSharp.Sql.StructField})">
@@ -6056,6 +7052,11 @@
             </summary>
             <param name="fields">The collection that holds StructField objects</param>
         </member>
+        <member name="P:Microsoft.Spark.CSharp.Sql.StructType.SimpleString">
+            <summary>
+            Returns a readable string that joins all <see cref="T:Microsoft.Spark.CSharp.Sql.StructField"/>s together.
+            </summary>
+        </member>
         <member name="M:Microsoft.Spark.CSharp.Sql.StructType.FromJson(Newtonsoft.Json.Linq.JObject)">
             <summary>
             Constructs a StructType from a Json object
@@ -6063,19 +7064,14 @@
             <param name="json">The Json object used to construct a StructType</param>
             <returns>A new StructType instance</returns>
         </member>
-        <member name="P:Microsoft.Spark.CSharp.Sql.StructType.Fields">
-            <summary>
-            Gets a list of StructField.
-            </summary>
-        </member>
-        <member name="P:Microsoft.Spark.CSharp.Sql.StructType.SimpleString">
-            <summary>
-            Returns a readable string that joins all <see cref="T:Microsoft.Spark.CSharp.Sql.StructField"/>s together.
-            </summary>
-        </member>
         <member name="T:Microsoft.Spark.CSharp.Streaming.ConstantInputDStream`1">
             <summary>
             An input stream that always returns the same RDD on each timestep. Useful for testing.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Streaming.ConstantInputDStream`1.#ctor(Microsoft.Spark.CSharp.Core.RDD{`0},Microsoft.Spark.CSharp.Streaming.StreamingContext)">
+            <summary>
+            Construct a ConstantInputDStream instance.
             </summary>
         </member>
         <member name="T:Microsoft.Spark.CSharp.Streaming.DStream`1">
@@ -6098,6 +7094,11 @@
              - A function that is used to generate an RDD after each time interval
             </summary>
             <typeparam name="T"></typeparam>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Streaming.DStream`1.SlideDuration">
+            <summary>
+            Return the slideDuration in seconds of this DStream
+            </summary>
         </member>
         <member name="M:Microsoft.Spark.CSharp.Streaming.DStream`1.Count">
             <summary>
@@ -6356,16 +7357,6 @@
             <param name="numPartitions">number of partitions of each RDD in the new DStream.</param>
             <returns></returns>
         </member>
-        <member name="P:Microsoft.Spark.CSharp.Streaming.DStream`1.SlideDuration">
-            <summary>
-            Return the slideDuration in seconds of this DStream
-            </summary>
-        </member>
-        <member name="M:Microsoft.Spark.CSharp.Streaming.ConstantInputDStream`1.#ctor(Microsoft.Spark.CSharp.Core.RDD{`0},Microsoft.Spark.CSharp.Streaming.StreamingContext)">
-            <summary>
-            Construct a ConstantInputDStream instance.
-            </summary>
-        </member>
         <member name="T:Microsoft.Spark.CSharp.Streaming.MapPartitionsWithIndexHelper`2">
             <summary>
             Following classes are defined explicitly instead of using anonymous method as delegate to prevent C# compiler from generating
@@ -6490,6 +7481,41 @@
                 If numPartitions = 0, repartition using original kafka partition count
                 If numPartitions > 0, repartition using this parameter
             </param>
+            <returns>A DStream object</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Streaming.KafkaUtils.CreateDirectStreamWithRepartitionAndReadFunc``1(Microsoft.Spark.CSharp.Streaming.StreamingContext,System.Collections.Generic.List{System.String},System.Collections.Generic.Dictionary{System.String,System.String},System.Collections.Generic.Dictionary{System.String,System.Int64},System.Int32,System.Func{System.Int32,System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.Byte[],System.Byte[]}},System.Collections.Generic.IEnumerable{``0}})">
+            <summary>
+            Create an input stream that directly pulls messages from a Kafka Broker and specific offset.
+            
+            This is not a receiver based Kafka input stream, it directly pulls the message from Kafka
+            in each batch duration and processed without storing.
+            
+            This does not use Zookeeper to store offsets. The consumed offsets are tracked
+            by the stream itself. For interoperability with Kafka monitoring tools that depend on
+            Zookeeper, you have to update Kafka/Zookeeper yourself from the streaming application.
+            You can access the offsets used in each batch from the generated RDDs (see
+            [[org.apache.spark.streaming.kafka.HasOffsetRanges]]).
+            To recover from driver failures, you have to enable checkpointing in the StreamingContext.
+            The information on consumed offset can be recovered from the checkpoint.
+            See the programming guide for details (constraints, etc.).
+            
+            </summary>
+            <param name="ssc">Spark Streaming Context</param>
+            <param name="topics">list of topic_name to consume.</param>
+            <param name="kafkaParams">
+                Additional params for Kafka. Requires "metadata.broker.list" or "bootstrap.servers" to be set
+                with Kafka broker(s) (NOT zookeeper servers), specified in host1:port1,host2:port2 form.        
+            </param>
+            <param name="fromOffsets">Per-topic/partition Kafka offsets defining the (inclusive) starting point of the stream.</param>
+            <param name="numPartitions">
+                user hint on how many kafka RDD partitions to create instead of aligning with kafka partitions,
+                unbalanced kafka partitions and/or under-distributed data will be redistributed evenly across 
+                a probably larger number of RDD partitions
+                If numPartitions = -1, either repartition based on spark.streaming.kafka.maxRatePerTask or do nothing if config not defined
+                If numPartitions = 0, repartition using original kafka partition count
+                If numPartitions > 0, repartition using this parameter
+            </param>
+            <param name="readFunc">user function to process the kafka data.</param>
             <returns>A DStream object</returns>
         </member>
         <member name="T:Microsoft.Spark.CSharp.Streaming.MapWithStateDStream`4">
@@ -6789,7 +7815,7 @@
              <param name="filterFunc">function to filter expired key-value pairs; only pairs that satisfy the function are retained set this to null if you do not want to filter</param>
              <returns></returns>
         </member>
-        <member name="M:Microsoft.Spark.CSharp.Streaming.PairDStreamFunctions.UpdateStateByKey``3(Microsoft.Spark.CSharp.Streaming.DStream{System.Collections.Generic.KeyValuePair{``0,``1}},System.Func{System.Collections.Generic.IEnumerable{``1},``2,``2},System.Int32)">
+        <member name="M:Microsoft.Spark.CSharp.Streaming.PairDStreamFunctions.UpdateStateByKey``3(Microsoft.Spark.CSharp.Streaming.DStream{System.Collections.Generic.KeyValuePair{``0,``1}},System.Func{System.Collections.Generic.IEnumerable{``1},``2,``2},Microsoft.Spark.CSharp.Core.RDD{System.Collections.Generic.KeyValuePair{``0,``2}},System.Int32)">
             <summary>
             Return a new "state" DStream where the state for each key is updated by applying
             the given function on the previous state of the key and the new values of the key.
@@ -6802,10 +7828,11 @@
                 State update function - (newValues, oldState) => newState
                 If this function returns None, then corresponding state key-value pair will be eliminated.
             </param>
+            <param name="initialState">Initial state value of each key</param>
             <param name="numPartitions"></param>
             <returns></returns>
         </member>
-        <member name="M:Microsoft.Spark.CSharp.Streaming.PairDStreamFunctions.UpdateStateByKey``3(Microsoft.Spark.CSharp.Streaming.DStream{System.Collections.Generic.KeyValuePair{``0,``1}},System.Func{System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{``0,System.Tuple{System.Collections.Generic.IEnumerable{``1},``2}}},System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{``0,``2}}},System.Int32)">
+        <member name="M:Microsoft.Spark.CSharp.Streaming.PairDStreamFunctions.UpdateStateByKey``3(Microsoft.Spark.CSharp.Streaming.DStream{System.Collections.Generic.KeyValuePair{``0,``1}},System.Func{System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{``0,System.Tuple{System.Collections.Generic.IEnumerable{``1},``2}}},System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{``0,``2}}},Microsoft.Spark.CSharp.Core.RDD{System.Collections.Generic.KeyValuePair{``0,``2}},System.Int32)">
             <summary>
             Return a new "state" DStream where the state for each key is updated by applying
             the given function on the previous state of the key and the new values of the key.
@@ -6815,10 +7842,11 @@
             <typeparam name="S"></typeparam>
             <param name="self"></param>
             <param name="updateFunc">State update function - IEnumerable[K, [newValues, oldState]] => IEnumerable[K, newState]</param>
+            <param name="initialState">Initial state value of each key</param>
             <param name="numPartitions"></param>
             <returns></returns>
         </member>
-        <member name="M:Microsoft.Spark.CSharp.Streaming.PairDStreamFunctions.UpdateStateByKey``3(Microsoft.Spark.CSharp.Streaming.DStream{System.Collections.Generic.KeyValuePair{``0,``1}},System.Func{System.Int32,System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{``0,System.Tuple{System.Collections.Generic.IEnumerable{``1},``2}}},System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{``0,``2}}},System.Int32)">
+        <member name="M:Microsoft.Spark.CSharp.Streaming.PairDStreamFunctions.UpdateStateByKey``3(Microsoft.Spark.CSharp.Streaming.DStream{System.Collections.Generic.KeyValuePair{``0,``1}},System.Func{System.Int32,System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{``0,System.Tuple{System.Collections.Generic.IEnumerable{``1},``2}}},System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{``0,``2}}},Microsoft.Spark.CSharp.Core.RDD{System.Collections.Generic.KeyValuePair{``0,``2}},System.Int32)">
             <summary>
             Return a new "state" DStream where the state for each key is updated by applying
             the given function on the previous state of the key and the new values of the key.
@@ -6828,6 +7856,7 @@
             <typeparam name="S"></typeparam>
             <param name="self"></param>
             <param name="updateFunc">State update function - (pid, IEnumerable[K, [newValues, oldState]]) => IEnumerable[K, newState]</param>
+            <param name="initialState">Initial state value of each key</param>
             <param name="numPartitions"></param>
             <returns></returns>
         </member>
@@ -6935,11 +7964,11 @@
             Wait for the execution to stop.
             </summary>
         </member>
-        <member name="M:Microsoft.Spark.CSharp.Streaming.StreamingContext.AwaitTerminationOrTimeout(System.Int32)">
+        <member name="M:Microsoft.Spark.CSharp.Streaming.StreamingContext.AwaitTerminationOrTimeout(System.Int64)">
             <summary>
             Wait for the execution to stop.
             </summary>
-            <param name="timeout">time to wait in seconds</param>
+            <param name="timeout">time to wait in milliseconds</param>
         </member>
         <member name="M:Microsoft.Spark.CSharp.Streaming.StreamingContext.Transform``1(System.Collections.Generic.IEnumerable{Microsoft.Spark.CSharp.Streaming.DStream{``0}},System.Func{System.Collections.Generic.IEnumerable{Microsoft.Spark.CSharp.Core.RDD{``0}},System.Int64,Microsoft.Spark.CSharp.Core.RDD{``0}})">
             <summary>

--- a/csharp/Adapter/documentation/Mobius_API_Documentation.md
+++ b/csharp/Adapter/documentation/Mobius_API_Documentation.md
@@ -142,13 +142,6 @@
             Used for collect operation on RDD
             
         
-###<font color="#68228B">Microsoft.Spark.CSharp.Core.IRDDCollector</font>
-####Summary
-  
-            
-            Interface for collect operation on RDD
-            
-        
 ###<font color="#68228B">Microsoft.Spark.CSharp.Core.DoubleRDDFunctions</font>
 ####Summary
   
@@ -163,6 +156,13 @@
 ---
   
   
+###<font color="#68228B">Microsoft.Spark.CSharp.Core.IRDDCollector</font>
+####Summary
+  
+            
+            Interface for collect operation on RDD
+            
+        
 ###<font color="#68228B">Microsoft.Spark.CSharp.Core.OrderedRDDFunctions</font>
 ####Summary
   
@@ -210,6 +210,13 @@
 ---
   
   
+###<font color="#68228B">Microsoft.Spark.CSharp.Core.Profiler</font>
+####Summary
+  
+            
+            A class represents a profiler
+            
+        
 ###<font color="#68228B">Microsoft.Spark.CSharp.Core.RDD`1</font>
 ####Summary
   
@@ -228,13 +235,6 @@
 ---
   
   
-###<font color="#68228B">Microsoft.Spark.CSharp.Core.Profiler</font>
-####Summary
-  
-            
-            A class represents a profiler
-            
-        
 ###<font color="#68228B">Microsoft.Spark.CSharp.Core.StringRDDFunctions</font>
 ####Summary
   
@@ -380,6 +380,125 @@
 ---
   
   
+###<font color="#68228B">Microsoft.Spark.CSharp.Network.ByteBuf</font>
+####Summary
+  
+            
+            ByteBuf delimits a section of a ByteBufChunk.
+            It is the smallest unit to be allocated.
+            
+        
+####Methods
+
+<table><tr><th>Name</th><th>Description</th></tr><tr><td><font color="blue">Clear</font></td><td>Sets the readerIndex and writerIndex of this buffer to 0.</td></tr><tr><td><font color="blue">IsReadable</font></td><td>Is this ByteSegment readable if and only if the buffer contains equal or more than the specified number of elements</td></tr><tr><td><font color="blue">IsWritable</font></td><td>Returns true if and only if the buffer has enough Capacity to accommodate size additional bytes.</td></tr><tr><td><font color="blue">ReadByte</font></td><td>Gets a byte at the current readerIndex and increases the readerIndex by 1 in this buffer.</td></tr><tr><td><font color="blue">ReadBytes</font></td><td>Reads a block of bytes from the ByteBuf and writes the data to a buffer.</td></tr><tr><td><font color="blue">Release</font></td><td>Release the ByteBuf back to the ByteBufPool</td></tr><tr><td><font color="blue">WriteBytes</font></td><td>Writes a block of bytes to the ByteBuf using data read from a buffer.</td></tr><tr><td><font color="blue">GetInputRioBuf</font></td><td>Returns a RioBuf object for input (receive)</td></tr><tr><td><font color="blue">GetOutputRioBuf</font></td><td>Returns a RioBuf object for output (send).</td></tr><tr><td><font color="blue">NewErrorStatusByteBuf</font></td><td>Creates an empty ByteBuf with error status.</td></tr><tr><td><font color="blue"></font></td><td>Finalizer.</td></tr><tr><td><font color="blue"></font></td><td>Allocates a ByteBuf from this ByteChunk.</td></tr><tr><td><font color="blue"></font></td><td>Release all resources</td></tr><tr><td><font color="blue"></font></td><td>Releases the ByteBuf back to this ByteChunk</td></tr><tr><td><font color="blue"></font></td><td>Returns a readable string for the ByteBufChunk</td></tr><tr><td><font color="blue"></font></td><td>Static method to create a new ByteBufChunk with given segment and chunk size. If isUnsafe is true, it allocates memory from the process's heap.</td></tr><tr><td><font color="blue"></font></td><td>Wraps HeapFree to process heap.</td></tr><tr><td><font color="blue"></font></td><td>Implementation of the Dispose pattern.</td></tr><tr><td><font color="blue"></font></td><td>Add the ByteBufChunk to this ByteBufChunkList linked-list based on ByteBufChunk's usage. So it will be moved to the right ByteBufChunkList that has the correct minUsage/maxUsage.</td></tr><tr><td><font color="blue"></font></td><td>Allocates a ByteBuf from this ByteBufChunkList if it is not empty.</td></tr><tr><td><font color="blue"></font></td><td>Releases the segment back to its ByteBufChunk.</td></tr><tr><td><font color="blue"></font></td><td>Adds the ByteBufChunk to this ByteBufChunkList</td></tr><tr><td><font color="blue"></font></td><td>Moves the ByteBufChunk down the ByteBufChunkList linked-list so it will end up in the right ByteBufChunkList that has the correct minUsage/maxUsage in respect to ByteBufChunk.Usage.</td></tr><tr><td><font color="blue"></font></td><td>Remove the ByteBufChunk from this ByteBufChunkList</td></tr><tr><td><font color="blue"></font></td><td>Returns a readable string for this ByteBufChunkList</td></tr><tr><td><font color="blue"></font></td><td>Allocates a ByteBuf from this ByteBufPool to use.</td></tr><tr><td><font color="blue"></font></td><td>Deallocates a ByteBuf back to this ByteBufPool.</td></tr><tr><td><font color="blue"></font></td><td>Gets a readable string for this ByteBufPool</td></tr><tr><td><font color="blue"></font></td><td>Returns the chunk numbers in each queue.</td></tr></table>
+
+---
+  
+  
+###<font color="#68228B">Microsoft.Spark.CSharp.Network.ByteBufChunk</font>
+####Summary
+  
+            
+            ByteBufChunk represents a memory blocks that can be allocated from 
+            .Net heap (managed code) or process heap(unsafe code)
+            
+        
+####Methods
+
+<table><tr><th>Name</th><th>Description</th></tr><tr><td><font color="blue">Finalize</font></td><td>Finalizer.</td></tr><tr><td><font color="blue">Allocate</font></td><td>Allocates a ByteBuf from this ByteChunk.</td></tr><tr><td><font color="blue">Dispose</font></td><td>Release all resources</td></tr><tr><td><font color="blue">Free</font></td><td>Releases the ByteBuf back to this ByteChunk</td></tr><tr><td><font color="blue">ToString</font></td><td>Returns a readable string for the ByteBufChunk</td></tr><tr><td><font color="blue">NewChunk</font></td><td>Static method to create a new ByteBufChunk with given segment and chunk size. If isUnsafe is true, it allocates memory from the process's heap.</td></tr><tr><td><font color="blue">FreeToProcessHeap</font></td><td>Wraps HeapFree to process heap.</td></tr><tr><td><font color="blue">Dispose</font></td><td>Implementation of the Dispose pattern.</td></tr><tr><td><font color="blue"></font></td><td>Add the ByteBufChunk to this ByteBufChunkList linked-list based on ByteBufChunk's usage. So it will be moved to the right ByteBufChunkList that has the correct minUsage/maxUsage.</td></tr><tr><td><font color="blue"></font></td><td>Allocates a ByteBuf from this ByteBufChunkList if it is not empty.</td></tr><tr><td><font color="blue"></font></td><td>Releases the segment back to its ByteBufChunk.</td></tr><tr><td><font color="blue"></font></td><td>Adds the ByteBufChunk to this ByteBufChunkList</td></tr><tr><td><font color="blue"></font></td><td>Moves the ByteBufChunk down the ByteBufChunkList linked-list so it will end up in the right ByteBufChunkList that has the correct minUsage/maxUsage in respect to ByteBufChunk.Usage.</td></tr><tr><td><font color="blue"></font></td><td>Remove the ByteBufChunk from this ByteBufChunkList</td></tr><tr><td><font color="blue"></font></td><td>Returns a readable string for this ByteBufChunkList</td></tr></table>
+
+---
+  
+  
+###<font color="#68228B">Microsoft.Spark.CSharp.Network.ByteBufChunk.Segment</font>
+####Summary
+  
+            
+            Segment struct delimits a section of a byte chunk.
+            
+        
+###<font color="#68228B">Microsoft.Spark.CSharp.Network.ByteBufChunkList</font>
+####Summary
+  
+            
+            ByteBufChunkList class represents a simple linked like list used to store ByteBufChunk objects
+            based on its usage.
+            
+        
+####Methods
+
+<table><tr><th>Name</th><th>Description</th></tr><tr><td><font color="blue">Add</font></td><td>Add the ByteBufChunk to this ByteBufChunkList linked-list based on ByteBufChunk's usage. So it will be moved to the right ByteBufChunkList that has the correct minUsage/maxUsage.</td></tr><tr><td><font color="blue">Allocate</font></td><td>Allocates a ByteBuf from this ByteBufChunkList if it is not empty.</td></tr><tr><td><font color="blue">Free</font></td><td>Releases the segment back to its ByteBufChunk.</td></tr><tr><td><font color="blue">AddInternal</font></td><td>Adds the ByteBufChunk to this ByteBufChunkList</td></tr><tr><td><font color="blue">MoveInternal</font></td><td>Moves the ByteBufChunk down the ByteBufChunkList linked-list so it will end up in the right ByteBufChunkList that has the correct minUsage/maxUsage in respect to ByteBufChunk.Usage.</td></tr><tr><td><font color="blue">Remove</font></td><td>Remove the ByteBufChunk from this ByteBufChunkList</td></tr><tr><td><font color="blue">ToString</font></td><td>Returns a readable string for this ByteBufChunkList</td></tr></table>
+
+---
+  
+  
+###<font color="#68228B">Microsoft.Spark.CSharp.Network.ByteBufPool</font>
+####Summary
+  
+            
+            ByteBufPool class is used to manage the ByteBuf pool that allocate and free pooled memory buffer.
+            We borrows some ideas from Netty buffer memory management.
+            
+        
+####Methods
+
+<table><tr><th>Name</th><th>Description</th></tr><tr><td><font color="blue">Allocate</font></td><td>Allocates a ByteBuf from this ByteBufPool to use.</td></tr><tr><td><font color="blue">Free</font></td><td>Deallocates a ByteBuf back to this ByteBufPool.</td></tr><tr><td><font color="blue">ToString</font></td><td>Gets a readable string for this ByteBufPool</td></tr><tr><td><font color="blue">GetUsages</font></td><td>Returns the chunk numbers in each queue.</td></tr></table>
+
+---
+  
+  
+###<font color="#68228B">Microsoft.Spark.CSharp.Network.RioNative</font>
+####Summary
+  
+            
+            RioNative class imports and initializes RIOSock.dll for use with RIO socket APIs.
+            It also provided a simple thread pool that retrieves the results from IO completion port.
+            
+        
+####Methods
+
+<table><tr><th>Name</th><th>Description</th></tr><tr><td><font color="blue">Finalize</font></td><td>Finalizer</td></tr><tr><td><font color="blue">Dispose</font></td><td>Release all resources.</td></tr><tr><td><font color="blue">SetUseThreadPool</font></td><td>Sets whether use thread pool to query RIO socket results, it must be called before calling EnsureRioLoaded()</td></tr><tr><td><font color="blue">EnsureRioLoaded</font></td><td>Ensures that the native dll of RIO socket is loaded and initialized.</td></tr><tr><td><font color="blue">UnloadRio</font></td><td>Explicitly unload the native dll of RIO socket, and release resources.</td></tr><tr><td><font color="blue">Init</font></td><td>Initializes RIOSock native library.</td></tr></table>
+
+---
+  
+  
+###<font color="#68228B">Microsoft.Spark.CSharp.Network.RioResult</font>
+####Summary
+  
+            
+            The RioResult structure contains data used to indicate request completion results used with RIO socket
+            
+        
+###<font color="#68228B">Microsoft.Spark.CSharp.Network.SocketStream</font>
+####Summary
+  
+            
+            Provides the underlying stream of data for network access.
+            Just like a NetworkStream.
+            
+        
+####Methods
+
+<table><tr><th>Name</th><th>Description</th></tr><tr><td><font color="blue">Flush</font></td><td>Flushes data from the stream. This is meaningless for us, so it does nothing.</td></tr><tr><td><font color="blue">Seek</font></td><td>Seeks a specific position in the stream. This method is not supported by the SocketDataStream class.</td></tr><tr><td><font color="blue">SetLength</font></td><td>Sets the length of the stream. This method is not supported by the SocketDataStream class.</td></tr><tr><td><font color="blue">ReadByte</font></td><td>Reads a byte from the stream and advances the position within the stream by one byte, or returns -1 if at the end of the stream.</td></tr><tr><td><font color="blue">Read</font></td><td>Reads data from the stream.</td></tr><tr><td><font color="blue">Write</font></td><td>Writes data to the stream.</td></tr></table>
+
+---
+  
+  
+###<font color="#68228B">Microsoft.Spark.CSharp.Network.SockDataToken</font>
+####Summary
+  
+            
+            SockDataToken class is used to associate with the SocketAsyncEventArgs object.
+            Primarily, it is a way to pass state to the event handler.
+            
+        
+####Methods
+
+<table><tr><th>Name</th><th>Description</th></tr><tr><td><font color="blue">Reset</font></td><td>Reset this token</td></tr><tr><td><font color="blue">DetachData</font></td><td>Detach the data ownership.</td></tr></table>
+
+---
+  
+  
 ###<font color="#68228B">Microsoft.Spark.CSharp.Network.SocketFactory</font>
 ####Summary
   
@@ -392,7 +511,7 @@
         
 ####Methods
 
-<table><tr><th>Name</th><th>Description</th></tr><tr><td><font color="blue">CreateSocket</font></td><td>Creates a ISocket instance based on the configuration and OS version.</td></tr></table>
+<table><tr><th>Name</th><th>Description</th></tr><tr><td><font color="blue">CreateSocket</font></td><td>Creates a ISocket instance based on the configuration and OS version.</td></tr><tr><td><font color="blue">IsRioSockSupported</font></td><td>Indicates whether current OS supports RIO socket.</td></tr></table>
 
 ---
   
@@ -510,21 +629,6 @@
 ---
   
   
-###<font color="#68228B">Microsoft.Spark.CSharp.Sql.SqlContext</font>
-####Summary
-  
-            
-            The entry point for working with structured data (rows and columns) in Spark.  
-            Allows the creation of [[DataFrame]] objects as well as the execution of SQL queries.
-            
-        
-####Methods
-
-<table><tr><th>Name</th><th>Description</th></tr><tr><td><font color="blue">GetOrCreate</font></td><td>Get the existing SQLContext or create a new one with given SparkContext.</td></tr><tr><td><font color="blue">NewSession</font></td><td>Returns a new SQLContext as new session, that has separate SQLConf, registered temporary tables and UDFs, but shared SparkContext and table cache.</td></tr><tr><td><font color="blue">GetConf</font></td><td>Returns the value of Spark SQL configuration property for the given key. If the key is not set, returns defaultValue.</td></tr><tr><td><font color="blue">SetConf</font></td><td>Sets the given Spark SQL configuration property.</td></tr><tr><td><font color="blue">Read</font></td><td>Returns a DataFrameReader that can be used to read data in as a DataFrame.</td></tr><tr><td><font color="blue">ReadDataFrame</font></td><td>Loads a dataframe the source path using the given schema and options</td></tr><tr><td><font color="blue">CreateDataFrame</font></td><td>Creates a from a RDD containing array of object using the given schema.</td></tr><tr><td><font color="blue">RegisterDataFrameAsTable</font></td><td>Registers the given as a temporary table in the catalog. Temporary tables exist only during the lifetime of this instance of SqlContext.</td></tr><tr><td><font color="blue">DropTempTable</font></td><td>Remove the temp table from catalog.</td></tr><tr><td><font color="blue">Table</font></td><td>Returns the specified table as a</td></tr><tr><td><font color="blue">Tables</font></td><td>Returns a containing names of tables in the given database. If is not specified, the current database will be used. The returned DataFrame has two columns: 'tableName' and 'isTemporary' (a column with bool type indicating if a table is a temporary one or not).</td></tr><tr><td><font color="blue">TableNames</font></td><td>Returns a list of names of tables in the database</td></tr><tr><td><font color="blue">CacheTable</font></td><td>Caches the specified table in-memory.</td></tr><tr><td><font color="blue">UncacheTable</font></td><td>Removes the specified table from the in-memory cache.</td></tr><tr><td><font color="blue">ClearCache</font></td><td>Removes all cached tables from the in-memory cache.</td></tr><tr><td><font color="blue">IsCached</font></td><td>Returns true if the table is currently cached in-memory.</td></tr><tr><td><font color="blue">Sql</font></td><td>Executes a SQL query using Spark, returning the result as a DataFrame. The dialect that is used for SQL parsing can be configured with 'spark.sql.dialect'</td></tr><tr><td><font color="blue">JsonFile</font></td><td>Loads a JSON file (one object per line), returning the result as a DataFrame It goes through the entire dataset once to determine the schema.</td></tr><tr><td><font color="blue">JsonFile</font></td><td>Loads a JSON file (one object per line) and applies the given schema</td></tr><tr><td><font color="blue">TextFile</font></td><td>Loads text file with the specific column delimited using the given schema</td></tr><tr><td><font color="blue">TextFile</font></td><td>Loads a text file (one object per line), returning the result as a DataFrame</td></tr><tr><td><font color="blue">RegisterFunction``1</font></td><td>Register UDF with no input argument, e.g: SqlContext.RegisterFunction&lt;bool&gt;("MyFilter", () =&gt; true); sqlContext.Sql("SELECT * FROM MyTable where MyFilter()");</td></tr><tr><td><font color="blue">RegisterFunction``2</font></td><td>Register UDF with 1 input argument, e.g: SqlContext.RegisterFunction&lt;bool, string&gt;("MyFilter", (arg1) =&gt; arg1 != null); sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1)");</td></tr><tr><td><font color="blue">RegisterFunction``3</font></td><td>Register UDF with 2 input arguments, e.g: SqlContext.RegisterFunction&lt;bool, string, string&gt;("MyFilter", (arg1, arg2) =&gt; arg1 != null &amp;&amp; arg2 != null); sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2)");</td></tr><tr><td><font color="blue">RegisterFunction``4</font></td><td>Register UDF with 3 input arguments, e.g: SqlContext.RegisterFunction&lt;bool, string, string, string&gt;("MyFilter", (arg1, arg2, arg3) =&gt; arg1 != null &amp;&amp; arg2 != null &amp;&amp; arg3 != null); sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, columnName3)");</td></tr><tr><td><font color="blue">RegisterFunction``5</font></td><td>Register UDF with 4 input arguments, e.g: SqlContext.RegisterFunction&lt;bool, string, string, ..., string&gt;("MyFilter", (arg1, arg2, ..., arg4) =&gt; arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg3 != null); sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName4)");</td></tr><tr><td><font color="blue">RegisterFunction``6</font></td><td>Register UDF with 5 input arguments, e.g: SqlContext.RegisterFunction&lt;bool, string, string, ..., string&gt;("MyFilter", (arg1, arg2, ..., arg5) =&gt; arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg5 != null); sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName5)");</td></tr><tr><td><font color="blue">RegisterFunction``7</font></td><td>Register UDF with 6 input arguments, e.g: SqlContext.RegisterFunction&lt;bool, string, string, ..., string&gt;("MyFilter", (arg1, arg2, ..., arg6) =&gt; arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg6 != null); sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName6)");</td></tr><tr><td><font color="blue">RegisterFunction``8</font></td><td>Register UDF with 7 input arguments, e.g: SqlContext.RegisterFunction&lt;bool, string, string, ..., string&gt;("MyFilter", (arg1, arg2, ..., arg7) =&gt; arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg7 != null); sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName7)");</td></tr><tr><td><font color="blue">RegisterFunction``9</font></td><td>Register UDF with 8 input arguments, e.g: SqlContext.RegisterFunction&lt;bool, string, string, ..., string&gt;("MyFilter", (arg1, arg2, ..., arg8) =&gt; arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg8 != null); sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName8)");</td></tr><tr><td><font color="blue">RegisterFunction``10</font></td><td>Register UDF with 9 input arguments, e.g: SqlContext.RegisterFunction&lt;bool, string, string, ..., string&gt;("MyFilter", (arg1, arg2, ..., arg9) =&gt; arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg9 != null); sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName9)");</td></tr><tr><td><font color="blue">RegisterFunction``11</font></td><td>Register UDF with 10 input arguments, e.g: SqlContext.RegisterFunction&lt;bool, string, string, ..., string&gt;("MyFilter", (arg1, arg2, ..., arg10) =&gt; arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg10 != null); sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName10)");</td></tr></table>
-
----
-  
-  
 ###<font color="#68228B">Microsoft.Spark.CSharp.Sql.PythonSerDe</font>
 ####Summary
   
@@ -605,6 +709,21 @@
 ####Methods
 
 <table><tr><th>Name</th><th>Description</th></tr><tr><td><font color="blue">GetStringValue</font></td><td>Gets the string for the value of SaveMode</td></tr></table>
+
+---
+  
+  
+###<font color="#68228B">Microsoft.Spark.CSharp.Sql.SqlContext</font>
+####Summary
+  
+            
+            The entry point for working with structured data (rows and columns) in Spark.  
+            Allows the creation of [[DataFrame]] objects as well as the execution of SQL queries.
+            
+        
+####Methods
+
+<table><tr><th>Name</th><th>Description</th></tr><tr><td><font color="blue">GetOrCreate</font></td><td>Get the existing SQLContext or create a new one with given SparkContext.</td></tr><tr><td><font color="blue">NewSession</font></td><td>Returns a new SQLContext as new session, that has separate SQLConf, registered temporary tables and UDFs, but shared SparkContext and table cache.</td></tr><tr><td><font color="blue">GetConf</font></td><td>Returns the value of Spark SQL configuration property for the given key. If the key is not set, returns defaultValue.</td></tr><tr><td><font color="blue">SetConf</font></td><td>Sets the given Spark SQL configuration property.</td></tr><tr><td><font color="blue">Read</font></td><td>Returns a DataFrameReader that can be used to read data in as a DataFrame.</td></tr><tr><td><font color="blue">ReadDataFrame</font></td><td>Loads a dataframe the source path using the given schema and options</td></tr><tr><td><font color="blue">CreateDataFrame</font></td><td>Creates a from a RDD containing array of object using the given schema.</td></tr><tr><td><font color="blue">RegisterDataFrameAsTable</font></td><td>Registers the given as a temporary table in the catalog. Temporary tables exist only during the lifetime of this instance of SqlContext.</td></tr><tr><td><font color="blue">DropTempTable</font></td><td>Remove the temp table from catalog.</td></tr><tr><td><font color="blue">Table</font></td><td>Returns the specified table as a</td></tr><tr><td><font color="blue">Tables</font></td><td>Returns a containing names of tables in the given database. If is not specified, the current database will be used. The returned DataFrame has two columns: 'tableName' and 'isTemporary' (a column with bool type indicating if a table is a temporary one or not).</td></tr><tr><td><font color="blue">TableNames</font></td><td>Returns a list of names of tables in the database</td></tr><tr><td><font color="blue">CacheTable</font></td><td>Caches the specified table in-memory.</td></tr><tr><td><font color="blue">UncacheTable</font></td><td>Removes the specified table from the in-memory cache.</td></tr><tr><td><font color="blue">ClearCache</font></td><td>Removes all cached tables from the in-memory cache.</td></tr><tr><td><font color="blue">IsCached</font></td><td>Returns true if the table is currently cached in-memory.</td></tr><tr><td><font color="blue">Sql</font></td><td>Executes a SQL query using Spark, returning the result as a DataFrame. The dialect that is used for SQL parsing can be configured with 'spark.sql.dialect'</td></tr><tr><td><font color="blue">JsonFile</font></td><td>Loads a JSON file (one object per line), returning the result as a DataFrame It goes through the entire dataset once to determine the schema.</td></tr><tr><td><font color="blue">JsonFile</font></td><td>Loads a JSON file (one object per line) and applies the given schema</td></tr><tr><td><font color="blue">TextFile</font></td><td>Loads text file with the specific column delimited using the given schema</td></tr><tr><td><font color="blue">TextFile</font></td><td>Loads a text file (one object per line), returning the result as a DataFrame</td></tr><tr><td><font color="blue">RegisterFunction``1</font></td><td>Register UDF with no input argument, e.g: SqlContext.RegisterFunction&lt;bool&gt;("MyFilter", () =&gt; true); sqlContext.Sql("SELECT * FROM MyTable where MyFilter()");</td></tr><tr><td><font color="blue">RegisterFunction``2</font></td><td>Register UDF with 1 input argument, e.g: SqlContext.RegisterFunction&lt;bool, string&gt;("MyFilter", (arg1) =&gt; arg1 != null); sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1)");</td></tr><tr><td><font color="blue">RegisterFunction``3</font></td><td>Register UDF with 2 input arguments, e.g: SqlContext.RegisterFunction&lt;bool, string, string&gt;("MyFilter", (arg1, arg2) =&gt; arg1 != null &amp;&amp; arg2 != null); sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2)");</td></tr><tr><td><font color="blue">RegisterFunction``4</font></td><td>Register UDF with 3 input arguments, e.g: SqlContext.RegisterFunction&lt;bool, string, string, string&gt;("MyFilter", (arg1, arg2, arg3) =&gt; arg1 != null &amp;&amp; arg2 != null &amp;&amp; arg3 != null); sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, columnName3)");</td></tr><tr><td><font color="blue">RegisterFunction``5</font></td><td>Register UDF with 4 input arguments, e.g: SqlContext.RegisterFunction&lt;bool, string, string, ..., string&gt;("MyFilter", (arg1, arg2, ..., arg4) =&gt; arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg3 != null); sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName4)");</td></tr><tr><td><font color="blue">RegisterFunction``6</font></td><td>Register UDF with 5 input arguments, e.g: SqlContext.RegisterFunction&lt;bool, string, string, ..., string&gt;("MyFilter", (arg1, arg2, ..., arg5) =&gt; arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg5 != null); sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName5)");</td></tr><tr><td><font color="blue">RegisterFunction``7</font></td><td>Register UDF with 6 input arguments, e.g: SqlContext.RegisterFunction&lt;bool, string, string, ..., string&gt;("MyFilter", (arg1, arg2, ..., arg6) =&gt; arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg6 != null); sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName6)");</td></tr><tr><td><font color="blue">RegisterFunction``8</font></td><td>Register UDF with 7 input arguments, e.g: SqlContext.RegisterFunction&lt;bool, string, string, ..., string&gt;("MyFilter", (arg1, arg2, ..., arg7) =&gt; arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg7 != null); sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName7)");</td></tr><tr><td><font color="blue">RegisterFunction``9</font></td><td>Register UDF with 8 input arguments, e.g: SqlContext.RegisterFunction&lt;bool, string, string, ..., string&gt;("MyFilter", (arg1, arg2, ..., arg8) =&gt; arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg8 != null); sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName8)");</td></tr><tr><td><font color="blue">RegisterFunction``10</font></td><td>Register UDF with 9 input arguments, e.g: SqlContext.RegisterFunction&lt;bool, string, string, ..., string&gt;("MyFilter", (arg1, arg2, ..., arg9) =&gt; arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg9 != null); sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName9)");</td></tr><tr><td><font color="blue">RegisterFunction``11</font></td><td>Register UDF with 10 input arguments, e.g: SqlContext.RegisterFunction&lt;bool, string, string, ..., string&gt;("MyFilter", (arg1, arg2, ..., arg10) =&gt; arg1 != null &amp;&amp; arg2 != null &amp;&amp; ... &amp;&amp; arg10 != null); sqlContext.Sql("SELECT * FROM MyTable where MyFilter(columnName1, columnName2, ..., columnName10)");</td></tr></table>
 
 ---
   
@@ -866,7 +985,7 @@
         
 ####Methods
 
-<table><tr><th>Name</th><th>Description</th></tr><tr><td><font color="blue">CreateStream</font></td><td>Create an input stream that pulls messages from a Kafka Broker.</td></tr><tr><td><font color="blue">CreateStream</font></td><td>Create an input stream that pulls messages from a Kafka Broker.</td></tr><tr><td><font color="blue">CreateDirectStream</font></td><td>Create an input stream that directly pulls messages from a Kafka Broker and specific offset. This is not a receiver based Kafka input stream, it directly pulls the message from Kafka in each batch duration and processed without storing. This does not use Zookeeper to store offsets. The consumed offsets are tracked by the stream itself. For interoperability with Kafka monitoring tools that depend on Zookeeper, you have to update Kafka/Zookeeper yourself from the streaming application. You can access the offsets used in each batch from the generated RDDs (see [[org.apache.spark.streaming.kafka.HasOffsetRanges]]). To recover from driver failures, you have to enable checkpointing in the StreamingContext. The information on consumed offset can be recovered from the checkpoint. See the programming guide for details (constraints, etc.).</td></tr><tr><td><font color="blue">CreateDirectStreamWithRepartition</font></td><td>Create an input stream that directly pulls messages from a Kafka Broker and specific offset. This is not a receiver based Kafka input stream, it directly pulls the message from Kafka in each batch duration and processed without storing. This does not use Zookeeper to store offsets. The consumed offsets are tracked by the stream itself. For interoperability with Kafka monitoring tools that depend on Zookeeper, you have to update Kafka/Zookeeper yourself from the streaming application. You can access the offsets used in each batch from the generated RDDs (see [[org.apache.spark.streaming.kafka.HasOffsetRanges]]). To recover from driver failures, you have to enable checkpointing in the StreamingContext. The information on consumed offset can be recovered from the checkpoint. See the programming guide for details (constraints, etc.).</td></tr></table>
+<table><tr><th>Name</th><th>Description</th></tr><tr><td><font color="blue">CreateStream</font></td><td>Create an input stream that pulls messages from a Kafka Broker.</td></tr><tr><td><font color="blue">CreateStream</font></td><td>Create an input stream that pulls messages from a Kafka Broker.</td></tr><tr><td><font color="blue">CreateDirectStream</font></td><td>Create an input stream that directly pulls messages from a Kafka Broker and specific offset. This is not a receiver based Kafka input stream, it directly pulls the message from Kafka in each batch duration and processed without storing. This does not use Zookeeper to store offsets. The consumed offsets are tracked by the stream itself. For interoperability with Kafka monitoring tools that depend on Zookeeper, you have to update Kafka/Zookeeper yourself from the streaming application. You can access the offsets used in each batch from the generated RDDs (see [[org.apache.spark.streaming.kafka.HasOffsetRanges]]). To recover from driver failures, you have to enable checkpointing in the StreamingContext. The information on consumed offset can be recovered from the checkpoint. See the programming guide for details (constraints, etc.).</td></tr><tr><td><font color="blue">CreateDirectStreamWithRepartition</font></td><td>Create an input stream that directly pulls messages from a Kafka Broker and specific offset. This is not a receiver based Kafka input stream, it directly pulls the message from Kafka in each batch duration and processed without storing. This does not use Zookeeper to store offsets. The consumed offsets are tracked by the stream itself. For interoperability with Kafka monitoring tools that depend on Zookeeper, you have to update Kafka/Zookeeper yourself from the streaming application. You can access the offsets used in each batch from the generated RDDs (see [[org.apache.spark.streaming.kafka.HasOffsetRanges]]). To recover from driver failures, you have to enable checkpointing in the StreamingContext. The information on consumed offset can be recovered from the checkpoint. See the programming guide for details (constraints, etc.).</td></tr><tr><td><font color="blue">CreateDirectStreamWithRepartitionAndReadFunc``1</font></td><td>Create an input stream that directly pulls messages from a Kafka Broker and specific offset. This is not a receiver based Kafka input stream, it directly pulls the message from Kafka in each batch duration and processed without storing. This does not use Zookeeper to store offsets. The consumed offsets are tracked by the stream itself. For interoperability with Kafka monitoring tools that depend on Zookeeper, you have to update Kafka/Zookeeper yourself from the streaming application. You can access the offsets used in each batch from the generated RDDs (see [[org.apache.spark.streaming.kafka.HasOffsetRanges]]). To recover from driver failures, you have to enable checkpointing in the StreamingContext. The information on consumed offset can be recovered from the checkpoint. See the programming guide for details (constraints, etc.).</td></tr></table>
 
 ---
   

--- a/csharp/AdapterTest/AdapterTest.csproj
+++ b/csharp/AdapterTest/AdapterTest.csproj
@@ -16,6 +16,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <CppDll Condition="Exists('..\..\cpp\x64')">HasCpp</CppDll>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -65,6 +66,10 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="ByteBufChunkListTest.cs" />
+    <Compile Include="ByteBufChunkTest.cs" />
+    <Compile Include="ByteBufPoolTest.cs" />
+    <Compile Include="ByteBufTest.cs" />
     <Compile Include="ColumnTest.cs" />
     <Compile Include="AccumulatorTest.cs" />
     <Compile Include="BroadcastTest.cs" />
@@ -81,6 +86,8 @@
     <Compile Include="PayloadHelperTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RowTest.cs" />
+    <Compile Include="SocketStreamTest.cs" />
+    <Compile Include="SocketWrapperTest.cs" />
     <Compile Include="SerDeTest.cs" />
     <Compile Include="HiveContextTest.cs" />
     <Compile Include="StatusTrackerTest.cs" />
@@ -89,9 +96,7 @@
     <Compile Include="DStreamTest.cs" />
     <Compile Include="Mocks\MockDStreamProxy.cs" />
     <Compile Include="Mocks\MockStreamingContextProxy.cs" />
-    <Compile Include="SparkCLRTestEnvironment.cs">
-      <SubType>Code</SubType>
-    </Compile>
+    <Compile Include="SparkCLRTestEnvironment.cs" />
     <Compile Include="DataFrameTest.cs" />
     <Compile Include="Mocks\MockSparkCLRProxy.cs" />
     <Compile Include="Mocks\MockConfigurationService.cs" />
@@ -121,7 +126,18 @@
       <Name>Tests.Common</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup Condition=" '$(CppDll)' == 'HasCpp' ">
+    <ContentWithTargetPath  Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Cpp\Riosock.pdb</Link>
+      <TargetPath>Riosock.dll</TargetPath>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath  Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.pdb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Cpp\Riosock.pdb</Link>
+      <TargetPath>Riosock.pdb</TargetPath>
+    </ContentWithTargetPath>
+  </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>

--- a/csharp/AdapterTest/ByteBufChunkListTest.cs
+++ b/csharp/AdapterTest/ByteBufChunkListTest.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.Spark.CSharp.Network;
+using NUnit.Framework;
+
+namespace AdapterTest
+{
+    [TestFixture]
+    public class ByteBufChunkListTest
+    {
+        private ByteBufPool bufPool;
+
+        [OneTimeSetUp]
+        public void CreatePooledBuffer()
+        {
+            bufPool = new ByteBufPool(1024, 2, false);
+        }
+
+        [Test]
+        public void TestAllocateAndFree()
+        {
+            var q50 = new ByteBufChunkList(null, 50, 200);
+            var q00 = new ByteBufChunkList(q50, 1, 50);
+            q00.PrevList = null;
+            q50.PrevList = q00;
+
+            // This chunk can only allocate 4 ByteBufs totally
+            var chunk1 = ByteBufChunk.NewChunk(bufPool, bufPool.SegmentSize, bufPool.ChunkSize, false);
+            var chunk2 = ByteBufChunk.NewChunk(bufPool, bufPool.SegmentSize, bufPool.ChunkSize, false);
+            var chunk3 = ByteBufChunk.NewChunk(bufPool, bufPool.SegmentSize, bufPool.ChunkSize, false);
+
+            //
+            // Verify Allocate()
+            //
+            q00.Add(chunk1);
+            // Verify the chunk is hosted in q50.
+            Assert.AreEqual(chunk1.ToString(), q00.ToString());
+            // Verify allocation success
+            ByteBuf byteBuf1;
+            Assert.IsTrue(q00.Allocate(out byteBuf1));
+            // Verify the chunk be moved to next list.
+            ByteBuf byteBuf2;
+            Assert.IsTrue(q00.Allocate(out byteBuf2));
+            Assert.AreEqual(chunk1.ToString(), q50.ToString()); // chunk1 is in q50 now
+
+            // Allocates from q50
+            ByteBuf byteBuf3;
+            Assert.IsTrue(q50.Allocate(out byteBuf3));
+            ByteBuf byteBuf4;
+            Assert.IsTrue(q50.Allocate(out byteBuf4));
+            // Verify failed allocation due to chunk 100% usage
+            ByteBuf byteBuf5;
+            Assert.AreEqual(100, chunk1.Usage);
+            Assert.IsFalse(q50.Allocate(out byteBuf5));
+            // Verify allocation success from chunk2
+            q50.Add(chunk2);
+            Assert.IsTrue(q50.Allocate(out byteBuf5));
+            Assert.AreEqual(chunk2, byteBuf5.ByteBufChunk);
+
+            //
+            // Verify Free()
+            //
+
+            // Build chunk1's chain for Free()
+            chunk1.Next = chunk3;
+            chunk3.Prev = chunk1;
+
+            // Verify Free() returns false due to chunk2's usage is 0
+            // that means the chunk need to be destroyed.
+            Assert.IsFalse(q50.Free(chunk2, byteBuf5));
+            q50.Add(chunk2);
+
+            // Free chunk1 from q50 now.
+            Assert.IsTrue(q50.Free(chunk1, byteBuf4));
+            Assert.IsTrue(q50.Free(chunk1, byteBuf3));
+            Assert.IsTrue(q50.Free(chunk1, byteBuf2));
+            Assert.AreEqual(chunk1.ToString(), q00.ToString()); // chunk1 is in q00 now
+            Assert.AreSame(q00, chunk1.Parent);
+            Assert.AreSame(chunk3, chunk2.Next);
+
+            // Free chunk1 from q00 now.
+            Assert.IsFalse(q00.Free(chunk1, byteBuf1));
+            Assert.AreEqual("none", q00.ToString()); // q00 is empty now
+        }
+    }
+}

--- a/csharp/AdapterTest/ByteBufChunkTest.cs
+++ b/csharp/AdapterTest/ByteBufChunkTest.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using Microsoft.Spark.CSharp.Network;
+using NUnit.Framework;
+
+namespace AdapterTest
+{
+    [TestFixture]
+    public class ByteBufChunkTest
+    {
+        private ByteBufPool managedBufPool;
+        private ByteBufPool unsafeBufPool;
+
+        [OneTimeSetUp]
+        public void CreatePooledBuffer()
+        {
+            managedBufPool = new ByteBufPool(1024, 2, false);
+            unsafeBufPool = new ByteBufPool(1024, 2, true);
+        }
+
+        [Test]
+        public void TestInvalidByteChunk()
+        {
+            // Input chunk size with 0
+            Assert.Throws<ArgumentNullException>(() => ByteBufChunk.NewChunk(managedBufPool, managedBufPool.SegmentSize, 0, false));
+
+            if (!SocketFactory.IsRioSockSupported()) return;
+            // Input chunk size with 0
+            Assert.Throws<ArgumentNullException>(() => ByteBufChunk.NewChunk(unsafeBufPool, unsafeBufPool.SegmentSize, 0, true));
+            // Input chunk size with negative value that caused HeapAlloc failed.
+            Assert.Throws<OutOfMemoryException>(() => ByteBufChunk.NewChunk(unsafeBufPool, unsafeBufPool.SegmentSize, -1, true));
+        }
+        
+        private void AllocateFreeBufChunkTest(ByteBufChunk chunk)
+        {
+            // Verify allocation
+            ByteBuf byteBuf1;
+            Assert.IsTrue(chunk.Allocate(out byteBuf1));
+            Assert.AreEqual(25, chunk.Usage);
+            ByteBuf byteBuf2;
+            Assert.IsTrue(chunk.Allocate(out byteBuf2));
+            Assert.AreEqual(50, chunk.Usage);
+            ByteBuf byteBuf3;
+            Assert.IsTrue(chunk.Allocate(out byteBuf3));
+            Assert.AreEqual(75, chunk.Usage);
+            ByteBuf byteBuf4;
+            Assert.IsTrue(chunk.Allocate(out byteBuf4));
+            Assert.AreEqual(100, chunk.Usage);
+            ByteBuf byteBuf5;
+            Assert.IsFalse(chunk.Allocate(out byteBuf5)); // Usage is 100%, cannot allocate
+            Assert.IsNull(byteBuf5);
+
+            // Verify Free()
+            chunk.Free(byteBuf1);
+            Assert.AreEqual(75, chunk.Usage);
+            chunk.Free(byteBuf2);
+            Assert.AreEqual(50, chunk.Usage);
+            chunk.Free(byteBuf3);
+            Assert.AreEqual(25, chunk.Usage);
+            chunk.Free(byteBuf4);
+            Assert.AreEqual(0, chunk.Usage);
+        }
+
+        [Test]
+        public void TestAllocateFreeManagedBufChunk()
+        {
+            // This chunk can only allocate 4 ByteBufs totally
+            var chunk = ByteBufChunk.NewChunk(managedBufPool, managedBufPool.SegmentSize, managedBufPool.ChunkSize, false);
+            AllocateFreeBufChunkTest(chunk);
+            chunk.Dispose();
+        }
+
+        [Test]
+        public void TestAllocateFreeUnsafeBufChunk()
+        {
+            if (!SocketFactory.IsRioSockSupported())
+            {
+                Assert.Ignore("Omitting due to missing Riosock.dll. It might caused by no VC++ build tool or running on an OS that not supports Windows RIO socket.");
+            }
+            // This chunk can only allocate 4 ByteBufs totally
+            var chunk = ByteBufChunk.NewChunk(unsafeBufPool, unsafeBufPool.SegmentSize, unsafeBufPool.ChunkSize, true);
+            Assert.AreNotEqual(IntPtr.Zero, chunk.BufId);
+            AllocateFreeBufChunkTest(chunk);
+            chunk.Dispose();
+        }
+    }
+}

--- a/csharp/AdapterTest/ByteBufPoolTest.cs
+++ b/csharp/AdapterTest/ByteBufPoolTest.cs
@@ -1,0 +1,158 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Spark.CSharp.Network;
+using NUnit.Framework;
+
+namespace AdapterTest
+{
+    [TestFixture]
+    public class ByteBufPoolTest
+    {
+        private ByteBufPool bufPool;
+        private ByteBufPool unsafeBufPool;
+
+        [OneTimeSetUp]
+        public void CreatePooledBuffer()
+        {
+            bufPool = new ByteBufPool(1024, ByteBufPool.DefaultChunkOrder, false);
+            if (SocketFactory.IsRioSockSupported())
+            {
+                unsafeBufPool = new ByteBufPool(1024, ByteBufPool.DefaultChunkOrder, true);
+            }
+        }
+
+        [Test]
+        public void TestManagedBufferAllocate()
+        {
+            var byteBuf = bufPool.Allocate();
+            var bufChunk = byteBuf.ByteBufChunk;
+            Assert.AreEqual(bufChunk.FreeBytes, bufChunk.Size - byteBuf.Capacity);
+            byteBuf.Release();
+            Assert.AreEqual(bufChunk.FreeBytes, bufChunk.Size);
+        }
+
+        [Test]
+        public void TestManagedBufferPoolGrow()
+        {
+            // Verify no chunks in 100% usage queue at beginning.
+            var chunkNumbers = bufPool.GetUsages();
+            Assert.AreEqual(0, chunkNumbers[5]); // The number of chunks in 100% usage queue should be 0 at beginning.
+
+            var bufs = new List<ByteBuf>();
+            for (var i = 0; i < 257; i++)
+            {
+                var byteBuf = bufPool.Allocate();
+                bufs.Add(byteBuf);
+            }
+
+            var firstChunk = bufs[255].ByteBufChunk;
+            var secondChunk = bufs[256].ByteBufChunk;
+
+            // Verify the buffer pool got grown.
+            Assert.AreNotSame(firstChunk, secondChunk);
+            // Verify the usage of the first buffer chunk
+            Assert.AreEqual(firstChunk.Usage, 100);
+            // Verify the usage of the second buffer chunk
+            Assert.AreEqual(secondChunk.Usage, 1);
+            // Verify the chunk exhaust and should be in 100% usage queue now.
+            chunkNumbers = bufPool.GetUsages();
+            Assert.AreNotEqual(0, chunkNumbers[5]); // The number of chunks in 100% usage queue should not be 0 now.
+            // Verify the ToString() shows as usage string.
+            var usageStr = bufPool.ToString();
+            Assert.IsTrue(usageStr.StartsWith("Chunk(s) at 0~25%"));
+
+            // Release buffers back to pool.
+            foreach (var byteBuf in bufs)
+            {
+                byteBuf.Release();
+            }
+
+            // Verify the first buffer chunk is disposed.
+            Assert.IsTrue(firstChunk.IsDisposed);
+            // Verify the usage of the second buffer chunk is 0.
+            Assert.AreEqual(secondChunk.Usage, 0);
+        }
+
+        [Test]
+        public void TestUnsafeBufferAllocate()
+        {
+            if (!SocketFactory.IsRioSockSupported())
+            {
+                Assert.Ignore("Omitting due to missing Riosock.dll. It might caused by no VC++ build tool or running on an OS that not supports Windows RIO socket.");
+            }
+
+            var byteBuf = unsafeBufPool.Allocate();
+            var bufChunk = byteBuf.ByteBufChunk;
+            Assert.AreNotEqual(IntPtr.Zero, bufChunk.UnsafeArray);
+            Assert.AreNotEqual(bufChunk.BufId, IntPtr.Zero);
+            Assert.AreEqual(bufChunk.FreeBytes, bufChunk.Size - byteBuf.Capacity);
+
+            // Verify GetInputRioBuf()
+            var inputRioBuf = byteBuf.GetInputRioBuf();
+            Assert.AreNotEqual(null, inputRioBuf);
+            Assert.AreEqual(byteBuf.WritableBytes, inputRioBuf.Length);
+
+            // Verify GetOutputRioBuf()
+            const string writeStr = "Write bytes to ByteBuf.";
+            var writeBytes = Encoding.UTF8.GetBytes(writeStr);
+            byteBuf.WriteBytes(writeBytes, 0, writeBytes.Length);
+            var outputRioBuf = byteBuf.GetOutputRioBuf();
+            Assert.AreNotEqual(null, outputRioBuf);
+            Assert.AreEqual(byteBuf.ReadableBytes, outputRioBuf.Length);
+
+            byteBuf.Release();
+            Assert.AreEqual(bufChunk.FreeBytes, bufChunk.Size);
+        }
+
+        [Test]
+        public void TestUnsafeBufferPoolGrow()
+        {
+            if (!SocketFactory.IsRioSockSupported())
+            {
+                Assert.Ignore("Omitting due to missing Riosock.dll. It might caused by no VC++ build tool or running on an OS that not supports Windows RIO socket.");
+            }
+
+            var bufs = new List<ByteBuf>();
+            for (var i = 0; i < 257; i++)
+            {
+                var byteBuf = unsafeBufPool.Allocate();
+                bufs.Add(byteBuf);
+            }
+
+            var firstChunk = bufs[255].ByteBufChunk;
+            var secondChunk = bufs[256].ByteBufChunk;
+
+            // Verify the buffer pool got grown.
+            Assert.AreNotSame(firstChunk, secondChunk);
+            Assert.AreNotEqual(firstChunk.BufId, secondChunk.BufId);
+            // Verify the usage of the first buffer chunk
+            Assert.AreEqual(firstChunk.Usage, 100);
+            // Verify the usage of the second buffer chunk
+            Assert.AreEqual(secondChunk.Usage, 1);
+
+            // Release buffers back to pool.
+            foreach (var byteBuf in bufs)
+            {
+                byteBuf.Release();
+            }
+
+            // Verify the first buffer chunk is disposed.
+            Assert.IsTrue(firstChunk.IsDisposed);
+            // Verify the usage of the second buffer chunk is 0.
+            Assert.AreEqual(secondChunk.Usage, 0);
+        }
+
+        [Test]
+        public void TestInvalidBufPool()
+        {
+            // Verify to new a ByteBufPool with a bigger chunkOrder which valid value is 0-14.
+            Assert.Throws<ArgumentException>(() => new ByteBufPool(1024, 15, false));
+            // Verify to new a ByteBugPool with a larger segment size to hit overflow of ByteBufChunk size.
+            Assert.Throws<ArgumentException>(() => new ByteBufPool(int.MaxValue, 8, false));
+        }
+    }
+}

--- a/csharp/AdapterTest/ByteBufTest.cs
+++ b/csharp/AdapterTest/ByteBufTest.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Text;
+using Microsoft.Spark.CSharp.Network;
+using NUnit.Framework;
+
+namespace AdapterTest
+{
+    [TestFixture]
+    public class ByteBufTest
+    {
+        private ByteBufPool managedBufPool;
+        private ByteBufPool unsafeBufPool;
+
+        [OneTimeSetUp]
+        public void CreatePooledBuffer()
+        {
+            managedBufPool = new ByteBufPool(1024, ByteBufPool.DefaultChunkOrder, false);
+            if (SocketFactory.IsRioSockSupported())
+            {
+                unsafeBufPool = new ByteBufPool(1024, ByteBufPool.DefaultChunkOrder, true);
+            }
+        }
+        
+        private void WriteReadByteBufTest(ByteBuf byteBuf)
+        {
+            var initWriteIndex = byteBuf.WriterIndex;
+            var initReadIndex = byteBuf.WriterIndex;
+            Assert.AreEqual(initWriteIndex, initReadIndex);
+            Assert.AreEqual(byteBuf.Capacity, byteBuf.WritableBytes);
+            Assert.AreEqual(0, byteBuf.ReadableBytes);
+            Assert.IsFalse(byteBuf.IsReadable());
+            Assert.IsTrue(byteBuf.IsWritable());
+
+            // Verify WriteBytes() function
+            const string writeStr = "Write bytes to ByteBuf.";
+            var writeBytes = Encoding.UTF8.GetBytes(writeStr);
+            byteBuf.WriteBytes(writeBytes, 0, writeBytes.Length);
+
+            Assert.AreEqual(initWriteIndex + writeBytes.Length, byteBuf.WriterIndex);
+            Assert.AreEqual(byteBuf.Capacity - writeBytes.Length, byteBuf.WritableBytes);
+            Assert.AreEqual(writeBytes.Length, byteBuf.ReadableBytes);
+            Assert.AreEqual(initReadIndex, byteBuf.ReaderIndex);
+            Assert.IsTrue(byteBuf.IsReadable());
+
+            // Verify ReadBytes() function
+            var readBytes = new byte[writeBytes.Length];
+            var ret = byteBuf.ReadBytes(readBytes, 0, readBytes.Length);
+            Assert.AreEqual(writeBytes.Length, ret);
+            var readStr = Encoding.UTF8.GetString(readBytes, 0, ret);
+            Assert.AreEqual(writeStr, readStr);
+
+            Assert.AreEqual(initWriteIndex + writeBytes.Length, byteBuf.WriterIndex);
+            Assert.AreEqual(byteBuf.Capacity - writeBytes.Length, byteBuf.WritableBytes);
+            Assert.AreEqual(0, byteBuf.ReadableBytes);
+            Assert.AreEqual(initReadIndex + ret, byteBuf.ReaderIndex);
+
+            // Verify ReadByte() function
+            byteBuf.WriteBytes(writeBytes, 0, 1);
+            var retByte = byteBuf.ReadByte();
+            Assert.AreEqual(writeBytes[0], retByte);
+
+            // Verify clear() function
+            byteBuf.Clear();
+            Assert.AreEqual(0, byteBuf.ReaderIndex);
+            Assert.AreEqual(0, byteBuf.WriterIndex);
+        }
+
+        [Test]
+        public void TestWriteReadManagedBuf()
+        {
+            var byteBuf = managedBufPool.Allocate();
+            Assert.AreEqual(IntPtr.Zero, byteBuf.UnsafeArray); // Verify the pointer of UnsafeArray is IntPtr.Zero on managed buffer.
+            WriteReadByteBufTest(byteBuf);
+            byteBuf.Release();
+        }
+
+        [Test]
+        public void TestWriteReadUnsafeBuf()
+        {
+            if (!SocketFactory.IsRioSockSupported())
+            {
+                Assert.Ignore("Omitting due to missing Riosock.dll. It might caused by no VC++ build tool or running on an OS that not supports Windows RIO socket.");
+            }
+
+            var byteBuf = unsafeBufPool.Allocate();
+            Assert.AreNotEqual(IntPtr.Zero, byteBuf.UnsafeArray); // Verify the point of UnsafeArray has value on unsafe buffer.
+            WriteReadByteBufTest(byteBuf);
+            byteBuf.Release();
+        }
+
+        [Test]
+        public void TestInvalidByteBuf()
+        {
+            // Test invalid parameter to new ByteBuf.
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ByteBuf(null, -1, 1024));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ByteBuf(null, 0, -1));
+            Assert.Throws<ArgumentNullException>(() => new ByteBuf(null, 0, 1024));
+            var byteBuf = managedBufPool.Allocate();
+            Assert.Throws<ArgumentException>(() => new ByteBuf(byteBuf.ByteBufChunk, byteBuf.ByteBufChunk.Size - 1, 1024));
+            byteBuf.Release();
+            // Test function on disposed ByteBuf.
+            Assert.IsFalse(byteBuf.IsWritable());
+            Assert.Throws<ObjectDisposedException>(() => byteBuf.ReadByte());
+            // Release double - nothing to do
+            byteBuf.Release();
+        }
+
+        [Test]
+        public void TestInvalidReadBytes()
+        {
+            var byteBuf = managedBufPool.Allocate();
+            var readBytes = new byte[10];
+            // Verify ReadBytes with invalid parameters
+            Assert.Throws<ArgumentNullException>(() => byteBuf.ReadBytes(null, 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => byteBuf.ReadBytes(readBytes, -1, 1024));
+            Assert.Throws<ArgumentOutOfRangeException>(() => byteBuf.ReadBytes(readBytes, 0, -1));
+            // Verify ReadBytes with invalid boundary
+            Assert.Throws<ArgumentException>(() => byteBuf.ReadBytes(readBytes, readBytes.Length - 1, readBytes.Length));
+            Assert.Throws<IndexOutOfRangeException>(() => byteBuf.ReadBytes(readBytes, 0, readBytes.Length));
+            byteBuf.Release();
+        }
+
+        [Test]
+        public void TestInvalidWriteBytes()
+        {
+            var byteBuf = managedBufPool.Allocate();
+            var writeBytes = new byte[2048];
+            // Verify WriteBytes with invalid parameters
+            Assert.Throws<ArgumentNullException>(() => byteBuf.WriteBytes(null, 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => byteBuf.WriteBytes(writeBytes, -1, 1024));
+            Assert.Throws<ArgumentOutOfRangeException>(() => byteBuf.WriteBytes(writeBytes, 0, -1));
+            // Verify WriteBytes with invalid boundary
+            Assert.Throws<ArgumentException>(() => byteBuf.WriteBytes(writeBytes, writeBytes.Length - 1, writeBytes.Length));
+            Assert.Throws<IndexOutOfRangeException>(() => byteBuf.WriteBytes(writeBytes, 0, 2048));
+        }
+
+        [Test]
+        public void TestInvalidWriterReaderIndex()
+        {
+            var byteBuf = managedBufPool.Allocate();
+            // Verify to set writer/reader index with a negative value.
+            Assert.Throws<IndexOutOfRangeException>(() => byteBuf.WriterIndex = -1);
+            Assert.Throws<IndexOutOfRangeException>(() => byteBuf.ReaderIndex = -1);
+
+            // Verify to set writer/reader index with an overflow value.
+            Assert.Throws<IndexOutOfRangeException>(() => byteBuf.ReaderIndex += 2);
+            Assert.Throws<IndexOutOfRangeException>(() => byteBuf.WriterIndex += (managedBufPool.SegmentSize + 1));
+            byteBuf.Release();
+        }
+
+        [Test]
+        public void TestGetRioBufFromManagedBuf()
+        {
+            var byteBuf = managedBufPool.Allocate();
+            // Verify to GetInputRioBuf()/GetOutputRioBuf() from a managed ByteBuf
+            Assert.Throws<InvalidOperationException>(() => byteBuf.GetInputRioBuf());
+            Assert.Throws<InvalidOperationException>(() => byteBuf.GetOutputRioBuf());
+            byteBuf.Release();
+        }
+    }
+}

--- a/csharp/AdapterTest/Mocks/MockConfigurationService.cs
+++ b/csharp/AdapterTest/Mocks/MockConfigurationService.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Spark.CSharp.Configuration;
+using Microsoft.Spark.CSharp.Network;
 
 namespace AdapterTest.Mocks
 {
@@ -24,6 +25,11 @@ namespace AdapterTest.Mocks
         public string GetCSharpWorkerExePath()
         {
             return workerPath;
+        }
+
+        public SocketWrapperType GetCSharpSocketType()
+        {
+            return SocketWrapperType.Normal;
         }
 
         public int BackendPortNumber

--- a/csharp/AdapterTest/SocketStreamTest.cs
+++ b/csharp/AdapterTest/SocketStreamTest.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.IO;
+using Microsoft.Spark.CSharp.Configuration;
+using Microsoft.Spark.CSharp.Network;
+using NUnit.Framework;
+
+namespace AdapterTest
+{
+    [TestFixture]
+    public class SocketStreamTest
+    {
+        /// <summary>
+        /// Only test invalid case.
+        /// The positive case verified on SocketWrapperTest
+        /// </summary>
+        [Test]
+        public void TestInvalidSocketStream()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SocketStream((SaeaSocketWrapper)null));
+            Assert.Throws<ArgumentNullException>(() => new SocketStream((RioSocketWrapper)null));
+
+            Environment.SetEnvironmentVariable(ConfigurationService.CSharpSocketTypeEnvName, "Saea");
+            SocketFactory.SocketWrapperType = SocketWrapperType.None;
+
+            using (var socket = SocketFactory.CreateSocket())
+            using (var stream = new SocketStream((SaeaSocketWrapper)socket))
+            {
+                // Verify SocketStream
+                Assert.IsTrue(stream.CanRead);
+                Assert.IsTrue(stream.CanWrite);
+                Assert.IsFalse(stream.CanSeek);
+                long lengh = 10;
+                Assert.Throws<NotSupportedException>(() => lengh = stream.Length);
+                Assert.Throws<NotSupportedException>(() => stream.Position = lengh);
+                Assert.Throws<NotSupportedException>(() => lengh = stream.Position);
+                Assert.Throws<NotSupportedException>(() => stream.Seek(lengh, SeekOrigin.Begin));
+                Assert.Throws<NotSupportedException>(() => stream.SetLength(lengh));
+            }
+
+            Environment.SetEnvironmentVariable(ConfigurationService.CSharpSocketTypeEnvName, string.Empty);
+            SocketFactory.SocketWrapperType = SocketWrapperType.None;
+        }
+    }
+}

--- a/csharp/AdapterTest/SocketWrapperTest.cs
+++ b/csharp/AdapterTest/SocketWrapperTest.cs
@@ -1,0 +1,204 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Spark.CSharp.Configuration;
+using Microsoft.Spark.CSharp.Network;
+using NUnit.Framework;
+
+namespace AdapterTest
+{
+    /// <summary>
+    /// Validates SaeaSocketWrapper by creating a ISocketWrapper server to 
+    /// simulate interactions between CSharpRDD and CSharpWorker
+    /// </summary>
+    [TestFixture]
+    public class SocketWrapperTest
+    {
+        private void SocketTest(ISocketWrapper serverSocket)
+        {
+            serverSocket.Listen();
+            if (serverSocket is RioSocketWrapper)
+            {
+                // Do nothing for second listen operation.
+                Assert.DoesNotThrow(() => serverSocket.Listen(int.MaxValue));
+            }
+
+            var port = ((IPEndPoint)serverSocket.LocalEndPoint).Port;
+
+            var clientMsg = "Hello Message from client";
+            var clientMsgBytes = Encoding.UTF8.GetBytes(clientMsg);
+
+            Task.Run(() =>
+            {
+                var bytes = new byte[1024];
+                using (var socket = serverSocket.Accept())
+                {
+                    using (var s = socket.GetStream())
+                    {
+                        // Receive data
+                        var bytesRec = s.Read(bytes, 0, bytes.Length);
+                        // send echo message.
+                        s.Write(bytes, 0, bytesRec);
+                        s.Flush();
+
+                        // Receive one byte
+                        var oneByte = s.ReadByte();
+
+                        // Send echo one byte
+                        byte[] oneBytes = { (byte)oneByte };
+                        s.Write(oneBytes, 0, oneBytes.Length);
+                        
+                        Thread.SpinWait(0);
+
+                        // Keep sending to ensure no memory leak
+                        var longBytes = Encoding.UTF8.GetBytes(new string('x', 8192));
+                        for (int i = 0; i < 1000; i++)
+                        {
+                            s.Write(longBytes, 0, longBytes.Length);
+                        }
+                        byte[] msg = Encoding.ASCII.GetBytes("This is a test<EOF>");
+                        s.Write(msg, 0, msg.Length);
+
+                        // Receive echo byte.
+                        s.ReadByte();
+                    }
+                }
+            });
+
+
+            var clientSock = SocketFactory.CreateSocket();
+
+            // Valid invalid operation
+            Assert.Throws<InvalidOperationException>(() => clientSock.GetStream());
+            Assert.Throws<InvalidOperationException>(() => clientSock.Receive());
+            Assert.Throws<InvalidOperationException>(() => clientSock.Send(null));
+            Assert.Throws<SocketException>(() => clientSock.Connect(IPAddress.Any, 1024));
+
+            clientSock.Connect(IPAddress.Loopback, port);
+
+            // Valid invalid operation
+            var byteBuf = ByteBufPool.Default.Allocate();
+            Assert.Throws<ArgumentException>(() => clientSock.Send(byteBuf));
+            byteBuf.Release();
+
+            Assert.Throws<SocketException>(() => clientSock.Listen());
+            if (clientSock is RioSocketWrapper)
+            {
+                Assert.Throws<InvalidOperationException>(() => clientSock.Accept());
+            }
+
+            using (var s = clientSock.GetStream())
+            {
+                // Send message
+                s.Write(clientMsgBytes, 0, clientMsgBytes.Length);
+                // Receive echo message
+                var bytes = new byte[1024];
+                var bytesRec = s.Read(bytes, 0, bytes.Length);
+                Assert.AreEqual(clientMsgBytes.Length, bytesRec);
+                var recvStr = Encoding.UTF8.GetString(bytes, 0, bytesRec);
+                Assert.AreEqual(clientMsg, recvStr);
+
+                // Send one byte
+                byte[] oneBytes = { 1 };
+                s.Write(oneBytes, 0, oneBytes.Length);
+
+                // Receive echo message
+                var oneByte = s.ReadByte();
+                Assert.AreEqual((byte)1, oneByte);
+
+                // Keep receiving to ensure no memory leak.
+                while (true)
+                {
+                    bytesRec = s.Read(bytes, 0, bytes.Length);
+                    recvStr = Encoding.UTF8.GetString(bytes, 0, bytesRec);
+                    if (recvStr.IndexOf("<EOF>", StringComparison.OrdinalIgnoreCase) > -1)
+                    {
+                        break;
+                    }
+                }
+                // send echo bytes
+                s.Write(oneBytes, 0, oneBytes.Length);
+            }
+
+            clientSock.Close();
+            // Verify invalid operation
+            Assert.Throws<ObjectDisposedException>(() => clientSock.Receive());
+
+            serverSocket.Close();
+        }
+
+        [Test]
+        public void TestSaeaSocket()
+        {
+            // Set Socket wrapper to Saea
+            Environment.SetEnvironmentVariable(ConfigurationService.CSharpSocketTypeEnvName, "Saea");
+            SocketFactory.SocketWrapperType = SocketWrapperType.None;
+            var serverSocket = SocketFactory.CreateSocket();
+            Assert.IsTrue(serverSocket is SaeaSocketWrapper);
+            SocketTest(serverSocket);
+            
+            // Reset socket wrapper type
+            Environment.SetEnvironmentVariable(ConfigurationService.CSharpSocketTypeEnvName, string.Empty);
+            SocketFactory.SocketWrapperType = SocketWrapperType.None;
+        }
+
+        [Test]
+        public void TestRioSocket()
+        {
+            if (!SocketFactory.IsRioSockSupported())
+            {
+                Assert.Ignore("Omitting due to missing Riosock.dll. It might caused by no VC++ build tool or running on an OS that not supports Windows RIO socket.");
+            }
+
+            // Set Socket wrapper to Rio
+            Environment.SetEnvironmentVariable(ConfigurationService.CSharpSocketTypeEnvName, "Rio");
+            SocketFactory.SocketWrapperType = SocketWrapperType.None;
+            RioSocketWrapper.rioRqGrowthFactor = 1;
+            var serverSocket = SocketFactory.CreateSocket();
+            Assert.IsTrue(serverSocket is RioSocketWrapper);
+            SocketTest(serverSocket);
+            
+            // Reset socket wrapper type
+            Environment.SetEnvironmentVariable(ConfigurationService.CSharpSocketTypeEnvName, string.Empty);
+            SocketFactory.SocketWrapperType = SocketWrapperType.None;
+            RioNative.UnloadRio();
+        }
+
+
+        [Test]
+        public void TestUseThreadPoolForRioNative()
+        {
+            if (!SocketFactory.IsRioSockSupported())
+            {
+                Assert.Ignore("Omitting due to missing Riosock.dll. It might caused by no VC++ build tool or running on an OS that not supports Windows RIO socket.");
+            }
+
+            RioNative.SetUseThreadPool(true);
+            RioNative.EnsureRioLoaded();
+            Assert.AreEqual(Environment.ProcessorCount, RioNative.GetWorkThreadNumber());
+            RioNative.UnloadRio();
+            RioNative.SetUseThreadPool(false);
+        }
+
+        [Test]
+        public void TestUseSingleThreadForRioNative()
+        {
+            if (!SocketFactory.IsRioSockSupported())
+            {
+                Assert.Ignore("Omitting due to missing Riosock.dll. It might caused by no VC++ build tool or running on an OS that not supports Windows RIO socket.");
+            }
+
+            RioNative.SetUseThreadPool(false);
+            RioNative.EnsureRioLoaded();
+            Assert.AreEqual(1, RioNative.GetWorkThreadNumber());
+            RioNative.UnloadRio();
+        }
+    }
+}

--- a/csharp/AdapterTest/SparkCLRTestEnvironment.cs
+++ b/csharp/AdapterTest/SparkCLRTestEnvironment.cs
@@ -2,16 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using AdapterTest.Mocks;
-using Microsoft.Spark.CSharp.Configuration;
 using Microsoft.Spark.CSharp.Interop;
 using Microsoft.Spark.CSharp.Interop.Ipc;
-using Microsoft.Spark.CSharp.Proxy;
-using Microsoft.Spark.CSharp.Proxy.Ipc;
 using NUnit.Framework;
 
 namespace AdapterTest
@@ -22,6 +15,7 @@ namespace AdapterTest
         [OneTimeSetUp]
         public static void Initialize()
         {
+            Console.WriteLine("Running SparkCLRTestEnvironment Initialize()");
             SparkCLREnvironment.SparkCLRProxy = new MockSparkCLRProxy();
             SparkCLREnvironment.ConfigurationService = new MockConfigurationService();
             SparkCLREnvironment.WeakObjectManager = new WeakObjectManagerImpl

--- a/csharp/Perf/Microsoft.Spark.CSharp/App.config
+++ b/csharp/Perf/Microsoft.Spark.CSharp/App.config
@@ -12,6 +12,6 @@
     <add key="CSharpWorkerPath" value="C:\SparkCLR\csharp\Samples\Microsoft.Spark.CSharp\bin\Debug\CSharpWorker.exe"/>    
     <add key="CSharpBackendPortNumber" value="0"/>
     -->
-
+    
   </appSettings>
 </configuration>

--- a/csharp/Perf/Microsoft.Spark.CSharp/FreebaseDeletionsBenchmark.cs
+++ b/csharp/Perf/Microsoft.Spark.CSharp/FreebaseDeletionsBenchmark.cs
@@ -23,6 +23,9 @@ namespace Microsoft.Spark.CSharp.PerfBenchmark
     ///     6. predicate (MID)
     ///     7. object (MID/Literal)
     ///     8. language_code
+    /// 
+    /// Note: You can add an additional column with any size data, if you want to increase
+    /// the size for each line.
     /// </summary>
     class FreebaseDeletionsBenchmark
     {

--- a/csharp/Perf/Microsoft.Spark.CSharp/PerfBenchmark.csproj
+++ b/csharp/Perf/Microsoft.Spark.CSharp/PerfBenchmark.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>SparkCLRPerf</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <CppDll Condition="Exists('..\..\..\cpp\x64')">HasCpp</CppDll>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -21,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -42,8 +44,20 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="data\deletionbenchmarktestdata.csv" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(CppDll)' == 'HasCpp' ">
+    <None Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Cpp\Riosock.dll</Link>
+    </None>
+    <None Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.pdb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Cpp\Riosock.pdb</Link>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Adapter\Microsoft.Spark.CSharp\Adapter.csproj">

--- a/csharp/Samples/Microsoft.Spark.CSharp/Samples.csproj
+++ b/csharp/Samples/Microsoft.Spark.CSharp/Samples.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>SparkCLRSamples</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <CppDll Condition="Exists('..\..\..\cpp\x64')">HasCpp</CppDll>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -78,7 +79,18 @@
     </None>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup Condition=" '$(CppDll)' == 'HasCpp' ">
+    <ContentWithTargetPath Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Cpp\Riosock.dll</Link>
+      <TargetPath>Riosock.dll</TargetPath>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.pdb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Cpp\Riosock.pdb</Link>
+      <TargetPath>Riosock.pdb</TargetPath>
+    </ContentWithTargetPath>
+  </ItemGroup>
   <ItemGroup>
     <Content Include="data\csvtestlog.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/csharp/Worker/Microsoft.Spark.CSharp/TaskRunner.cs
+++ b/csharp/Worker/Microsoft.Spark.CSharp/TaskRunner.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Spark.CSharp
     /// TaskRunner is used to run Spark task assigned by JVM side. It uses a TCP socket to
     /// communicate with JVM side. This socket may be reused to run multiple Spark tasks.
     /// </summary>
-    public class TaskRunner
+    internal class TaskRunner
     {
         private static ILoggerService logger = null;
         private ILoggerService Logger

--- a/csharp/Worker/Microsoft.Spark.CSharp/Worker.cs
+++ b/csharp/Worker/Microsoft.Spark.CSharp/Worker.cs
@@ -38,9 +38,10 @@ namespace Microsoft.Spark.CSharp
             // can't initialize logger early because in MultiThreadWorker mode, JVM will read C#'s stdout via
             // pipe. When initialize logger, some unwanted info will be flushed to stdout. But we can still
             // use stderr
-            Console.Error.WriteLine("input args: [{0}]", string.Join(" ", args));
+            Console.Error.WriteLine("input args: [{0}] SocketWrapper: [{1}]",
+                string.Join(" ", args), SocketFactory.SocketWrapperType);
 
-            if (args.Count() != 2)
+            if (args.Length != 2)
             {
                 Console.Error.WriteLine("Wrong number of args: {0}, will exit", args.Count());
                 Environment.Exit(-1);
@@ -48,6 +49,14 @@ namespace Microsoft.Spark.CSharp
 
             if ("pyspark.daemon".Equals(args[1]))
             {
+                if (SocketFactory.SocketWrapperType == SocketWrapperType.Rio)
+                {
+                    // In daemon mode, the socket will be used as server.
+                    // Use ThreadPool to retrieve RIO socket results has good performance
+                    // than a single thread.
+                    RioNative.SetUseThreadPool(true);
+                }
+                
                 var multiThreadWorker = new MultiThreadWorker();
                 multiThreadWorker.Run();
             }

--- a/csharp/Worker/Microsoft.Spark.CSharp/Worker.csproj
+++ b/csharp/Worker/Microsoft.Spark.CSharp/Worker.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>CSharpWorker</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <CppDll Condition="Exists('..\..\..\cpp\x64')">HasCpp</CppDll>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -50,7 +51,18 @@
     <Compile Include="TaskRunner.cs" />
     <Compile Include="Worker.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup Condition=" '$(CppDll)' == 'HasCpp' ">
+    <ContentWithTargetPath Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Cpp\Riosock.dll</Link>
+      <TargetPath>Riosock.dll</TargetPath>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.pdb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Cpp\Riosock.pdb</Link>
+      <TargetPath>Riosock.pdb</TargetPath>
+    </ContentWithTargetPath>
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Adapter\Microsoft.Spark.CSharp\Adapter.csproj">
       <Project>{ce999a96-f42b-4e80-b208-709d7f49a77c}</Project>

--- a/csharp/WorkerTest/WorkerTest.csproj
+++ b/csharp/WorkerTest/WorkerTest.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -11,6 +10,13 @@
     <AssemblyName>WorkerTest</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <CppDll Condition="Exists('..\..\cpp\x64')">HasCpp</CppDll>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -70,6 +76,18 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(CppDll)' == 'HasCpp' ">
+    <ContentWithTargetPath Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Cpp\Riosock.dll</Link>
+      <TargetPath>Riosock.dll</TargetPath>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.pdb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Cpp\Riosock.pdb</Link>
+      <TargetPath>Riosock.pdb</TargetPath>
+    </ContentWithTargetPath>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/csharp/build.sh
+++ b/csharp/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export FWDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
+export CppDll=NoCpp
 export XBUILDOPT=/verbosity:minimal
 
 if [ -z $builduri ];
@@ -37,7 +37,7 @@ export CONFIGURATION=$STEP
 
 export STEP=$CONFIGURATION
 
-xbuild /p:Configuration=$CONFIGURATION $XBUILDOPT $PROJ
+xbuild "/p:Configuration=$CONFIGURATION;AllowUnsafeBlocks=true" $XBUILDOPT $PROJ
 export RC=$? && [ $RC -ne 0 ] && error_exit
 echo "BUILD ok for $CONFIGURATION $PROJ"
 
@@ -46,7 +46,7 @@ export STEP=Release
 
 export CONFIGURATION=$STEP
 
-xbuild /p:Configuration=$CONFIGURATION $XBUILDOPT $PROJ
+xbuild "/p:Configuration=$CONFIGURATION;AllowUnsafeBlocks=true" $XBUILDOPT $PROJ
 export RC=$? && [ $RC -ne 0 ] && error_exit
 echo "BUILD ok for $CONFIGURATION $PROJ"
 

--- a/examples/Build.cmd
+++ b/examples/Build.cmd
@@ -7,6 +7,7 @@ set CMDHOME=%CMDHOME:~0,-1%
 
 @REM Set msbuild location.
 SET VisualStudioVersion=12.0
+if EXIST "%VS140COMNTOOLS%" SET VisualStudioVersion=14.0
 
 SET MSBUILDEXEDIR=%programfiles(x86)%\MSBuild\%VisualStudioVersion%\Bin
 if NOT EXIST "%MSBUILDEXEDIR%\." SET MSBUILDEXEDIR=%programfiles%\MSBuild\%VisualStudioVersion%\Bin

--- a/notes/configuration-mobius.md
+++ b/notes/configuration-mobius.md
@@ -7,5 +7,6 @@
 |Streaming (Kafka)  |spark.mobius.streaming.kafka.fetchRate  |Set the number of Kafka metadata fetch operation per batch |
 |Streaming (Kafka)  |spark.mobius.streaming.kafka.numReceivers  |Set the number of threads used to materialize the RDD created by applying the user read function to the original KafkaRDD. |
 |Streaming (UpdateStateByKey)  |spark.mobius.streaming.parallelJobs  |Sets 0-based max number of parallel jobs for UpdateStateByKey so that next N batches can start its tasks on time even if previous batch not completed yet. default: 0, recommended: 1. It's a special version of spark.streaming.concurrentJobs which does not observe UpdateStateByKey's state ordering properly  |
+|Worker  |spark.mobius.CSharp.socketType  |Sets the socket type that will be used in IPC for csharp code. default: Normal, if no any configuration. Normal means use default .Net Socket class for IPC; Rio, use Windows RIO socket for IPC; Saea, use .Net Socket class with SocketAsyncEventArgs class for IPC.  Riosocket and SaeaSocket has better performance on dealing larger data transmission than traditional .Net Socket. You can switch the socket type when you has large data transmission (we can see the performance improvement for over 4KB per transmission in average) between JVM and CLR.  |
 
 

--- a/notes/windows-instructions.md
+++ b/notes/windows-instructions.md
@@ -10,6 +10,9 @@ The following environment variables should be set properly in the Developer Comm
 
 * `JAVA_HOME`
 
+**To Be Noticed**: 
+Mobius on Windows includes a C++ component - RIOSock.dll. If your environment does not have VC++ Build Toolset installed, the C++ component will be skipped to compile. Offically, the C++ component is always compiled on AppVeyor.
+Please enable VC++ component from Visual Studio, or you can download [Visual C++ Build Tools](http://landinghub.visualstudio.com/visual-cpp-build-tools), if you want to build C++ components.
 
 ## Instructions
 

--- a/scala/src/main/org/apache/spark/api/csharp/CSharpRDD.scala
+++ b/scala/src/main/org/apache/spark/api/csharp/CSharpRDD.scala
@@ -72,6 +72,11 @@ class CSharpRDD(
       logInfo(s"workerFactoryId: $workerFactoryId")
     }
 
+    if (!CSharpRDD.csharpWorkerSocketType.isEmpty) {
+      envVars.put("spark.mobius.CSharp.socketType", CSharpRDD.csharpWorkerSocketType)
+      logInfo(s"CSharpWorker socket type: $CSharpRDD.csharpWorkerSocketType")
+    }
+
     val runner = new PythonRunner(
       command, envVars, cSharpIncludes, cSharpWorker.getAbsolutePath, unUsedVersionIdentifier,
       broadcastVars, accumulator, bufferSize, reuse_worker)
@@ -200,6 +205,8 @@ object CSharpRDD {
 
   // long running multi-process CSharpWorker mode is enabled only when configurated explicitly
   var maxCSharpWorkerProcessCount: Int = SparkEnv.get.conf.getInt("spark.mobius.CSharpWorker.maxProcessCount", -1)
+  // socket type for CSharpWorker
+  var csharpWorkerSocketType: String = SparkEnv.get.conf.get("spark.mobius.CSharp.socketType", "")
 
   def createRDDFromArray(
       sc: SparkContext,


### PR DESCRIPTION
Run Sparkclrsperf.exe for perf suite RunRDDMaxDeletionsByUser only (because this suite invoke CSharpWorker).

There is 11% perf improvement by using RIO socket for the file with 4KB a line, and 15% perf improvement for the file with 64KB a line.

Traditional Socket for file with 4KB a line:
User with max deletions is /user/mwcl_musicbrainz, count of deletions=237776. Elapsed time=00:04:35.1505607
Requesting to close all call back sockets.
** Printing results of the perf run (C#) **
** Execution time for RunRDDMaxDeletionsByUser in Milliseconds. Min=275150, Max=275150, Average=275150, Median=275150, Number of runs=1, Individual execution duration=[275150] **
** *** **

Rio Socket for file with 4KB a line:
User with max deletions is /user/mwcl_musicbrainz, count of deletions=237776. Elapsed time=00:04:07.2763483
Requesting to close all call back sockets.
** Printing results of the perf run (C#) **
** Execution time for RunRDDMaxDeletionsByUser in Milliseconds. Min=247276, Max=247276, Average=247276, Median=247276, Number of runs=1, Individual execution duration=[247276] **
** *** **

Traditional Socket for file with 64KB a line:
User with max deletions is /user/mwcl_musicbrainz, count of deletions=5167. Elapsed time=00:01:47.3907642
** Printing results of the perf run (C#) **
** Execution time for RunRDDMaxDeletionsByUser in Milliseconds. Min=107390, Max=107390, Average=107390, Median=107390, Number of runs=1, Individual execution duration=[107390] **
** *** **

Rio Socket for file with 64KB a line:
User with max deletions is /user/mwcl_musicbrainz, count of deletions=5167. Elapsed time=00:01:33.1928019
** Printing results of the perf run (C#) **
** Execution time for RunRDDMaxDeletionsByUser in Milliseconds. Min=93192, Max=93192, Average=93192, Median=93192, Number of runs=1, Individual execution duration=[93192] **
** *** **

Perf results for RIO socket by SocketTest.exe(No spark):
send/recv data without operation: 164.4418838 seconds/10000 messages (10 MB per message)
send/recv data with operation: 1026.1169171 seconds/10000 messages (10 MB per message)

Perf results for tradition socket by SocketTest.exe(No spark):
send/recv data without operation: 1159.0978946 seconds/10000 messages (10 MB per message)
send/recv data with operation: 2555.039326 seconds/10000 messages (10 MB per message)
