### PR TITLE
updating maven version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ before_install:
   - sudo apt-get install xsltproc
   - nuget install NUnit.Runners -Version 3.0.0 -OutputDirectory testrunner
   # install maven 3.3.3
-  - wget http://archive.apache.org/dist/maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.tar.gz
-  - tar zxf apache-maven-3.3.3-bin.tar.gz && rm apache-maven-3.3.3-bin.tar.gz
-  - export M2_HOME="$PWD/apache-maven-3.3.3"
+  - wget http://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz
+  - tar zxf apache-maven-3.3.9-bin.tar.gz && rm apache-maven-3.3.9-bin.tar.gz
+  - export M2_HOME="$PWD/apache-maven-3.3.9"
   - export M2="$M2_HOME/bin"
   - export PATH="$M2:$PATH"
   - hash -r

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.6.1-SNAPSHOT.{build}
+version: 1.6.2-SNAPSHOT.{build}
 
 environment:
   securefile:          

--- a/build/localmode/downloadtools.ps1
+++ b/build/localmode/downloadtools.ps1
@@ -213,11 +213,11 @@ function Download-BuildTools
     }
     
     # Apache Maven
-	$mvnVer = "apache-maven-3.3.3"
+	$mvnVer = "apache-maven-3.3.9"
     $mvnCmd = "$toolsDir\$mvnVer\bin\mvn.cmd"
     if (!(test-path $mvnCmd))
     {
-        $url = "http://www.us.apache.org/dist/maven/maven-3/3.3.3/binaries/$mvnVer-bin.tar.gz"
+        $url = "http://www.us.apache.org/dist/maven/maven-3/3.3.9/binaries/$mvnVer-bin.tar.gz"
         $output="$toolsDir\$mvnVer-bin.tar.gz"
         Download-File $url $output
         Untar-File $output $toolsDir


### PR DESCRIPTION
Version 3.3.3 is no longer available at http://www.us.apache.org/dist/maven/maven-3. Upgrading to the latest version.