### PR TITLE
Set default logger to log4net ; Reduce logs of WeakObjectManager.

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Interop/Ipc/WeakObjectManager.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Interop/Ipc/WeakObjectManager.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Spark.CSharp.Interop.Ipc
                 int previousReferencesCountBenchmark = referencesCountBenchmark;
                 checkCount *= 2;
                 referencesCountBenchmark = referencesCountBenchmark + referencesCountBenchmark / 2;
-                logger.LogInfo("Adjust checkCount from {0} to {1}, referencesCountBenchmark from {2} to {3}",
+                logger.LogDebug("Adjust checkCount from {0} to {1}, referencesCountBenchmark from {2} to {3}",
                     previousCheckCount, checkCount, previousReferencesCountBenchmark, referencesCountBenchmark);
             }
             return checkCount;
@@ -134,7 +134,7 @@ namespace Microsoft.Spark.CSharp.Interop.Ipc
 
         private void RunReleaseObjectLoop()
         {
-            logger.LogInfo("Checking objects thread start ...");
+            logger.LogDebug("Checking objects thread start ...");
             while (shouldKeepRunning)
             {
                 ReleseGarbageCollectedObjects();
@@ -179,7 +179,7 @@ namespace Microsoft.Spark.CSharp.Interop.Ipc
             aliveList.ForEach(item => weakReferences.Enqueue(item));
             var timeStoreAlive = DateTime.Now;
 
-            logger.LogInfo("check end : released {0} garbage, remain {1} alive, used {2} ms : release garbage used {3} ms, store alive used {4} ms",
+            logger.LogDebug("check end : released {0} garbage, remain {1} alive, used {2} ms : release garbage used {3} ms, store alive used {4} ms",
                     garbageCount, weakReferences.Count, (DateTime.Now - beginTime).TotalMilliseconds,
                     (timeReleaseGarbage - beginTime).TotalMilliseconds,
                     (timeStoreAlive - timeReleaseGarbage).TotalMilliseconds

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Services/LoggerServiceFactory.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Services/LoggerServiceFactory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Spark.CSharp.Services
     /// </summary>
     public class LoggerServiceFactory
     {
-        private static ILoggerService loggerService = DefaultLoggerService.Instance;
+        private static ILoggerService loggerService = Log4NetLoggerService.Instance;
         
         /// <summary>
         /// Overrides an existing logger by a given logger service instance


### PR DESCRIPTION
1.Too many logs generated especially after last update of WeakObjectManager, and cannot be suppressed by setting higher log level.

2.Default logger in LoggerServiceFactory not suppresses undesired lower level log messages.

3.To use log4net logger need to call LoggerServiceFactory.SetLoggerService() before using GetLogger(), but most usages not. Probably because coders follow a convention that just use one line of code to define and create a logger.
So many classes using LoggerServiceFactory will encounter the same problem of WeakObjectManager that application cannot suppress undesired log messages.

