### PR TITLE
Fix bugs in RioSocketWrapper and SocketStream that cause vstest failed

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Network/ByteBufChunk.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Network/ByteBufChunk.cs
@@ -234,7 +234,7 @@ namespace Microsoft.Spark.CSharp.Network
             var token = HeapAlloc(GetProcessHeap(), 0, chunkSize);
             if (token == IntPtr.Zero)
             {
-                throw new OutOfMemoryException();
+                throw new OutOfMemoryException("Failed to allocate memory by calling HeapAlloc()");
             }
 
             // register this heap buffer to RIO buffer
@@ -242,7 +242,7 @@ namespace Microsoft.Spark.CSharp.Network
             if (bufferId == IntPtr.Zero)
             {
                 FreeToProcessHeap(token);
-                throw new Exception("Failed to register RIO buffer");
+                throw new Exception(string.Format("Failed to register RIO buffer with error code {0}", Marshal.GetLastWin32Error()));
             }
 
             try

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Network/ByteBufPool.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Network/ByteBufPool.cs
@@ -119,14 +119,22 @@ namespace Microsoft.Spark.CSharp.Network
             }
 
             // Add a new chunk and allocate a segment from it.
-            var chunk = ByteBufChunk.NewChunk(this, SegmentSize, ChunkSize, isUnsafe);
-            if (!chunk.Allocate(out byteBuf))
+            try
             {
-                logger.LogError("Failed to allocate a ByteBuf from a new ByteBufChunk. {0}", chunk);
+                var chunk = ByteBufChunk.NewChunk(this, SegmentSize, ChunkSize, isUnsafe);
+                if (!chunk.Allocate(out byteBuf))
+                {
+                    logger.LogError("Failed to allocate a ByteBuf from a new ByteBufChunk - isUnsafe [{0}].", isUnsafe);
+                    return null;
+                }
+                qInit.Add(chunk);
+                return byteBuf;
+            }
+            catch (Exception e)
+            {
+                logger.LogException(e);
                 return null;
             }
-            qInit.Add(chunk);
-            return byteBuf;
         }
 
         /// <summary>

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Network/RioSocketWrapper.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Network/RioSocketWrapper.cs
@@ -499,6 +499,13 @@ namespace Microsoft.Spark.CSharp.Network
                 return;
             }
 
+            if (status == 0 && byteTransferred == 0)
+            {
+                // The remote has gracefully closed the connection
+                logger.LogDebug("ProcessReceive() with status(0) and byteTransferred(0). The connection has been gracefully closed.");
+                return;
+            }
+
             // Posts another receive operation
             DoReceive();
         }

--- a/csharp/WorkerTest/MultiThreadWorkerTest.cs
+++ b/csharp/WorkerTest/MultiThreadWorkerTest.cs
@@ -183,19 +183,21 @@ namespace WorkerTest
         /// <param name="exitCode"></param>
         private void AssertWorker(Process worker, int exitCode = 0, string errorMessage = null)
         {
-            if (!worker.WaitForExit(3000))
+            if (!worker.WaitForExit(30000))
             {
+                Console.WriteLine("Time out for worker.WaitForExit(). Force to kill worker process.");
                 worker.Kill();
             }
+
             string str;
             lock (syncLock)
             {
                 str = output.ToString();
-                Console.WriteLine("output from server: {0}", str);
             }
+            Assert.IsTrue(errorMessage == null || str.Contains(errorMessage),
+                string.Format("Actual output from worker: {0}{1}", Environment.NewLine, str));
             Assert.IsTrue(worker.HasExited);
             Assert.AreEqual(exitCode, worker.ExitCode);
-            Assert.IsTrue(errorMessage == null || str.Contains(errorMessage));
         }
 
 


### PR DESCRIPTION
This is to fix bugs in RioSocketWrapper and SocketStream that cause vstest.console.exe with /enablecodecoverage failed.