### PR TITLE
Implement automatic code coverage reports for c++ code

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,9 +41,12 @@ test:
 # scripts to run after tests
 after_test:
     - cmd: echo [after_test] ProjectVersion=%ProjectVersion%
+    - .\build\tools\Dynamic-Code-Coverage-Tools\CodeCoverage.exe collect /output:NativeCodeCoverage.coverage .\csharp\packages\NUnit.Console.3.0.1\tools\nunit3-console.exe .\csharp\WorkerTest\bin\Debug\WorkerTest.dll .\csharp\AdapterTest\bin\Debug\AdapterTest.dll
+    - .\build\tools\Dynamic-Code-Coverage-Tools\CodeCoverage.exe analyze /output:NativeCodeCoverage.xml NativeCodeCoverage.coverage
     - .\csharp\packages\OpenCover.4.6.166\tools\OpenCover.Console.exe -register:user -target:.\csharp\packages\NUnit.Console.3.0.1\tools\nunit3-console.exe -register:user "-targetargs:"".\csharp\WorkerTest\bin\Debug\WorkerTest.dll"" "".\csharp\AdapterTest\bin\Debug\AdapterTest.dll"" " -filter:"+[CSharpWorker*|Microsoft.Spark.CSharp*]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -hideskipped:All -output:.\SparkCLRCodeCoverage.xml
     - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
     - pip install codecov
+    - codecov -f "NativeCodeCoverage.xml"
     - codecov -f "SparkCLRCodeCoverage.xml"
     - cmd: cd .\build\localmode
     - cmd: if not defined ProjectVersion (.\Runsamples.cmd --validate)

--- a/build/localmode/downloadtools.ps1
+++ b/build/localmode/downloadtools.ps1
@@ -306,6 +306,25 @@ function Download-BuildTools
             $envStream.WriteLine("set path=$gpgBin\;%path%");
     	}
     }
+    
+        # Dynamic Code Coverage Tools
+    if ($env:APPVEYOR -eq "true")
+    {
+        $covZip = "$toolsDir\dynamic-code-coverage-tools.zip"
+        if (!(test-path $covZip))
+        {
+            $url = "https://github.com/MobiusForSpark/build/blob/master/tools/dynamic-code-coverage-tools.zip?raw=true"
+            $output=$covZip
+            Download-File $url $output
+            # Unzip-File $output $toolsDir
+            Write-Output "[downloadtools.Download-BuildTools] Extracting $output to $toolsDir ..."
+            Invoke-Expression "& 7z x $output -o$toolsDir"
+        }
+        else
+        {
+            Write-Output "[downloadtools.Download-BuildTools] $covZip exists already. No download and extraction needed"
+        }
+    }
 
     # Download winutils.exe
     Download-Winutils


### PR DESCRIPTION
Using Dynamic Code Coverage Tools of Visual Studio to generate C++ code coverage reports in CodeCov.io.

Limitation:
Currently, CodeCov can supports the reports generated by Dynamic Code Coverage Tools of Visual Studio with only one module. CodeCov is working on the fix to support multiple modules in the reports. In the meanwhile, CodeCov is also working on to support the reports generated by vstest.consle.exe with /enablecodecoverage parameter.
Please see [https://github.com/codecov/support/issues/255] for more information.