### PR TITLE
Add read and write buffer for CSharpWorker

### DIFF
--- a/csharp/Worker/Microsoft.Spark.CSharp/App.config
+++ b/csharp/Worker/Microsoft.Spark.CSharp/App.config
@@ -37,6 +37,10 @@
   </log4net>
 
   <appSettings>
+    <!--Buffer size in bytes for operation of reading data from JVM process -->
+    <add key="CSharpWorkerReadBufferSize" value="4096"/>
+    <!--Buffer size in bytes for operation of writing data to JVM process -->
+    <add key="CSharpWorkerWriteBufferSize" value="4096"/>
   </appSettings>
 
 </configuration>

--- a/csharp/Worker/Microsoft.Spark.CSharp/Worker.csproj
+++ b/csharp/Worker/Microsoft.Spark.CSharp/Worker.csproj
@@ -42,6 +42,7 @@
       <HintPath>..\..\packages\Razorvine.Serpent.1.12.0.0\lib\net40\Razorvine.Serpent.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>


### PR DESCRIPTION
For CSharpWorker, in some scenarios adding buffer with proper size can significantly improve the r/w performance using socket, a typical scenario is  that large amount of small records are written to JVM process.

* Use a `BufferedStream` to wrap `NetworkStream` to provide buffer functionality. 


* Buffer size for read and write operation can be configured independently in `CSharpWorker.exe.config`
 * `CSharpWorkerReadBufferSize` - Buffer size in bytes for operation of reading data from JVM process, by default is 8KB
 * `CSharpWorkerWriteBufferSize` - Buffer size in bytes for operation of writing data to JVM process, by default is 8KB