### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,8 +46,9 @@ SparkCLRCodeCoverage.xml
 AdapterTestCoverage.xml
 TestResult.xml
 csharp/SparkCLR.compiled.nuspec
+cpp/Riosock.sdf
 
 # Office Doc Temp files #
 #########################
-docs/~$SparkCLR.pptx
-docs/~$arkCLR.docx
+docs/~$Mobius.pptx
+docs/~$Mobius.docx


### PR DESCRIPTION
Since the .pptx and .docx file name has changed to `Mobius`, we should update .gitignore file.
I also add the Riosock.sdf file which generated when I open this cpp project in VS.