### PR TITLE
Improve the implementation of RDD TakeOrdered and Top operations

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Adapter.csproj
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Adapter.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Core\OrderedRDDFunctions.cs" />
     <Compile Include="Core\PairRDDFunctions.cs" />
     <Compile Include="Core\PipelinedRDD.cs" />
+    <Compile Include="Core\PriorityQueue.cs" />
     <Compile Include="Core\Profiler.cs" />
     <Compile Include="Core\RDD.cs" />
     <Compile Include="Core\SparkConf.cs" />

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Core/PriorityQueue.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Core/PriorityQueue.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Spark.CSharp.Core
             var i = elementCount;
             if (i >= queue.Length)
             {
-                if (GE(queue[0], e)) // compare it with root of the heap
+                if (GT(queue[0], e)) // compare it with root of the heap
                 {
                     queue[0] = e;
                     SiftDownHeapRoot();
@@ -77,7 +77,7 @@ namespace Microsoft.Spark.CSharp.Core
                 var child = (k << 1) + 1;
                 var c = queue[child];
                 var right = child + 1;
-                if (right < elementCount && GE(queue[right], c))
+                if (right < elementCount && GT(queue[right], c))
                 {
                     c = queue[child = right];
                 }
@@ -112,10 +112,16 @@ namespace Microsoft.Spark.CSharp.Core
             queue[k] = x;
         }
 
+        // helper method for comparision
+        private bool GT(T a, T b)
+        {
+            return comparer.Compare(a, b) > 0;
+        }
+
         // great or equal, helper method for comparision
         private bool GE(T a, T b)
         {
-            return comparer.Compare(a, b) > 0;
+            return comparer.Compare(a, b) >= 0;
         }
 
         public IEnumerator<T> GetEnumerator()

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Core/PriorityQueue.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Core/PriorityQueue.cs
@@ -1,0 +1,134 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.Spark.CSharp.Core
+{
+    /// <summary>
+    /// A bounded priority queue implemented with max binary heap.
+    /// 
+    /// Construction steps:
+    ///  1. Build a Max Heap of the first k elements.
+    ///  2. For each element after the kth element, compare it with the root of the max heap,
+    ///    a. If the element is less than the root, replace root with this element, heapify.
+    ///    b. Else ignore it.
+    /// </summary>
+    [Serializable]
+    internal class PriorityQueue<T> : IEnumerable<T> where T : IComparable<T>
+    {
+        // The number of elements in the priority queue.
+        private int elementCount;
+        private T[] queue;
+        private Comparer<T> comparer;
+
+        /// <summary>
+        /// Constructor of PriorityQueue type.
+        /// </summary>
+        internal PriorityQueue(int queueSize, Comparer<T> comparer)
+        {
+            this.comparer = comparer;
+            queue = new T[queueSize];
+        }
+
+        /// <summary>
+        /// Inserts the specified element into this priority queue.
+        /// </summary>
+        internal void Offer(T e)
+        {
+            if (ReferenceEquals(null, e))
+            {
+                throw new NullReferenceException();
+            }
+
+            var i = elementCount;
+            if (i >= queue.Length)
+            {
+                if (GE(queue[0], e)) // compare it with root of the heap
+                {
+                    queue[0] = e;
+                    SiftDownHeapRoot();
+                }
+
+                return;
+            }
+
+            elementCount = i + 1;
+            if (i == 0)
+            {
+                queue[0] = e;
+            }
+            else
+            {
+                SiftUp(i, e);
+            }
+        }
+
+        private void SiftDownHeapRoot()
+        {
+            var x = queue[0];
+            var half = (int)((uint)elementCount >> 1);
+            var k = 0;
+
+            while (k < half)
+            {
+                var child = (k << 1) + 1;
+                var c = queue[child];
+                var right = child + 1;
+                if (right < elementCount && GE(queue[right], c))
+                {
+                    c = queue[child = right];
+                }
+
+                if (GE(x, c))
+                {
+                    break;
+                }
+
+                queue[k] = c;
+                k = child;
+            }
+
+            queue[k] = x;
+        }
+
+        private void SiftUp(int k, T x)
+        {
+            while (k > 0)
+            {
+                var parent = (int)((uint)(k - 1) >> 1);
+                var e = queue[parent];
+                if (GE(e, x)) // if parent >= child, stop
+                {
+                    break;
+                }
+
+                queue[k] = e;
+                k = parent;
+            }
+
+            queue[k] = x;
+        }
+
+        // great or equal, helper method for comparision
+        private bool GE(T a, T b)
+        {
+            return comparer.Compare(a, b) > 0;
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            for (var i = 0; i < elementCount; i++)
+            {
+                yield return queue[i];
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Core/RDD.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Core/RDD.cs
@@ -1151,8 +1151,16 @@ namespace Microsoft.Spark.CSharp.Core
         /// <returns></returns>
         public static T[] TakeOrdered<T>(this RDD<T> self, int num, Func<T, dynamic> keyFunc = null) where T : IComparable<T>
         {
-            return self.MapPartitionsWithIndex<T>(new TakeOrderedHelper<T>(num, keyFunc).Execute).Collect()
-                .OrderBy(x => keyFunc == null ? x : keyFunc(x)).Take(num).ToArray();
+            return self.TakeOrdered(num, true, keyFunc);
+        }
+
+        internal static T[] TakeOrdered<T>(this RDD<T> self, int num, bool ascending, Func<T, dynamic> keyFunc = null) where T : IComparable<T>
+        {
+            var helper = new TakeOrderedHelper<T>(num, keyFunc, ascending);
+            return self.MapPartitionsWithIndex(helper.Execute)
+                    .Reduce(helper.Execute2)
+                    .OrderBy(x => keyFunc == null ? x : keyFunc(x))
+                    .ToArray();
         }
 
         /// <summary>
@@ -1170,7 +1178,7 @@ namespace Microsoft.Spark.CSharp.Core
         /// <returns></returns>
         public static T[] Top<T>(this RDD<T> self, int num) where T : IComparable<T>
         {
-            return self.MapPartitionsWithIndex<T>(new TopHelper<T>(num).Execute).Collect().OrderByDescending(x => x).Take(num).ToArray();
+            return self.TakeOrdered(num, false).OrderByDescending(x => x).ToArray();
         }
     }
 
@@ -1463,33 +1471,65 @@ namespace Microsoft.Spark.CSharp.Core
         }
     }
     [Serializable]
-    internal class TakeOrderedHelper<T>
+    internal class TakeOrderedHelper<T> where T : IComparable<T>
     {
         private readonly int num;
         private readonly Func<T, dynamic> keyFunc;
-        internal TakeOrderedHelper(int num, Func<T, dynamic> keyFunc)
+        private readonly bool ascending;
+
+        internal TakeOrderedHelper(int num, Func<T, dynamic> keyFunc, bool ascending)
         {
             this.num = num;
             this.keyFunc = keyFunc;
+            this.ascending = ascending;
         }
-        internal IEnumerable<T> Execute(int pid, IEnumerable<T> input)
+        internal IEnumerable<PriorityQueue<T>> Execute(int pid, IEnumerable<T> input)
         {
-            return input.OrderBy(x => keyFunc == null ? x : keyFunc(x)).Take(num);
+            Comparer<T> comparer;
+
+            if (ascending)
+            {
+                if (keyFunc != null)
+                {
+                    comparer = Comparer<T>.Create((x, y) => ((IComparable) keyFunc(x)).CompareTo(keyFunc(y)));
+                }
+                else
+                {
+                    comparer = Comparer<T>.Create((x, y) => x.CompareTo(y));
+                }
+            }
+            else
+            {
+                if (keyFunc == null)
+                {
+                    comparer = Comparer<T>.Create((x, y) => y.CompareTo(x));
+                }
+                else
+                {
+                    comparer = Comparer<T>.Create((x, y) => ((IComparable)keyFunc(y)).CompareTo(keyFunc(x)));
+                }
+            }
+           
+            var priorityQueue = new PriorityQueue<T>(num, comparer);
+            foreach (var e in input)
+            {
+                priorityQueue.Offer(e);
+            }
+
+            return new[] { priorityQueue };
+        }
+
+        internal PriorityQueue<T> Execute2(PriorityQueue<T> queue1, PriorityQueue<T> queue2)
+        {
+            foreach (var e in queue1)
+            {
+                queue2.Offer(e);
+            }
+
+            return queue2;
         }
     }
-    [Serializable]
-    internal class TopHelper<T>
-    {
-        private readonly int num;
-        internal TopHelper(int num)
-        {
-            this.num = num;
-        }
-        internal IEnumerable<T> Execute(int pid, IEnumerable<T> input)
-        {
-            return input.OrderByDescending(x => x).Take(num);
-        }
-    }
+
     [Serializable]
     internal class ZipWithUniqueIdHelper<T>
     {

--- a/csharp/AdapterTest/AdapterTest.csproj
+++ b/csharp/AdapterTest/AdapterTest.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Mocks\MockRDDCollector.cs" />
     <Compile Include="Mocks\MockRow.cs" />
     <Compile Include="PayloadHelperTest.cs" />
+    <Compile Include="PriorityQueueTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RowTest.cs" />
     <Compile Include="SocketStreamTest.cs" />

--- a/csharp/AdapterTest/PriorityQueueTest.cs
+++ b/csharp/AdapterTest/PriorityQueueTest.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Spark.CSharp.Core;
+using NUnit.Framework;
+
+namespace AdapterTest
+{
+    /// <summary>
+    /// Validates functionality of PriorityQueue
+    /// </summary>
+    [TestFixture]
+    class PriorityQueueTest
+    {
+        internal List<int> GetRandomList(int size)
+        {
+            var rand = new Random(DateTime.Now.Millisecond);
+            return Enumerable.Range(0, size).Select(i => rand.Next()).ToList();
+        }
+
+        [Test]
+        public void Test()
+        { 
+            // build a random list
+            var randoms = GetRandomList(60);
+            
+            // create a priority queue
+            var size = 6;
+            var queue = new PriorityQueue<int>(size, Comparer<int>.Create((x, y) => x - y));
+
+            // feed numbers to queue
+            randoms.ForEach(queue.Offer);
+            randoms.Sort();
+
+            // verify
+            var expected = randoms.Take(size);
+            Assert.AreEqual(expected.ToArray(), queue.OrderBy(x => x).ToArray());
+        }
+
+        [Test]
+        public void TestDuplication()
+        {
+            var numbers = new [] { -1, -1, -1, 1, 1, 2, 3, 9, 20, 15, 11 }.ToList();
+
+            var queue = new PriorityQueue<int>(1, Comparer<int>.Create((x, y) => x - y));
+            numbers.ForEach(queue.Offer);
+            Assert.AreEqual(-1, queue.ToArray()[0]);
+
+            queue = new PriorityQueue<int>(3, Comparer<int>.Create((x, y) => x - y));
+            numbers.ForEach(queue.Offer);
+            queue.ToList().ForEach(x => Assert.AreEqual(-1, x));
+
+            queue = new PriorityQueue<int>(4, Comparer<int>.Create((x, y) => x - y));
+            numbers.ForEach(queue.Offer);
+            Assert.AreEqual(1, queue.OrderBy(x => x).Last());
+
+            queue = new PriorityQueue<int>(100, Comparer<int>.Create((x, y) => x - y));
+            numbers.ForEach(queue.Offer);
+            Assert.AreEqual(20, queue.OrderBy(x => x).Last());
+        }
+
+        [Test]
+        public void TestReverseOrder()
+        {
+            var randoms = GetRandomList(100);
+            var queue = new PriorityQueue<int>(3, Comparer<int>.Create((x, y) => y - x));
+            randoms.ForEach(queue.Offer);
+            var expected = randoms.OrderByDescending(x => x).Take(3);
+            Assert.AreEqual(expected.ToArray(), queue.OrderByDescending(x => x).ToArray());
+        }
+
+        [Test]
+        public void TestNull()
+        {
+            Assert.Throws<NullReferenceException>(() => new PriorityQueue<string>(5, Comparer<string>.Create((x, y) => String.Compare(x, y, StringComparison.Ordinal))).Offer(null));
+        }
+    }
+}


### PR DESCRIPTION
Current implementation for RDD `TakeOrdered` and `Top` operations is based on in-memory sort, which can't handle the scenario that partition data is too large to fit into memory.

This PR tries to solve this problem by 
* Using a bounded priority queue to find out the top K elements for each partition, priority queue only holds K elements in memory and don't need to sort all data first
* Adding an extra `Reduce` operation to aggregate the result data from each partition.
* Implementing `Top` operation by `TakeOrdered` operation.