### PR TITLE
Fix SocketStream.ReadByte() to release unreadable cache

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Adapter.csproj
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Adapter.csproj
@@ -154,12 +154,12 @@
     <Compile Include="Streaming\TransformedDStream.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(CppDll)' == 'HasCpp' ">
-    <ContentWithTargetPath Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.dll">
+    <ContentWithTargetPath Include="..\..\..\cpp\x64\$(ConfigurationName)\Riosock.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>Cpp\Riosock.dll</Link>
       <TargetPath>Riosock.dll</TargetPath>
     </ContentWithTargetPath>
-    <ContentWithTargetPath Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.pdb">
+    <ContentWithTargetPath Include="..\..\..\cpp\x64\$(ConfigurationName)\Riosock.pdb">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>Cpp\Riosock.dll</Link>
       <TargetPath>Riosock.pdb</TargetPath>

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Network/SocketStream.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Network/SocketStream.cs
@@ -124,7 +124,14 @@ namespace Microsoft.Spark.CSharp.Network
                 recvDataCache = streamSocket.Receive();
             }
 
-            return recvDataCache.ReadByte();
+            var v = recvDataCache.ReadByte();
+            if (recvDataCache.IsReadable()) return v;
+
+            // Release cache if it is not readable. If we do not reset the cache here,
+            // the cache will be used in next Read() that caused 0 bytes return.
+            recvDataCache.Release();
+            recvDataCache = null;
+            return v;
         }
 
         /// <summary>

--- a/csharp/AdapterTest/AdapterTest.csproj
+++ b/csharp/AdapterTest/AdapterTest.csproj
@@ -16,7 +16,6 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
-    <CppDll Condition="Exists('..\..\cpp\x64')">HasCpp</CppDll>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -125,18 +124,6 @@
       <Project>{e4479c4c-e106-4b90-bf0c-319561cea9c4}</Project>
       <Name>Tests.Common</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup Condition=" '$(CppDll)' == 'HasCpp' ">
-    <ContentWithTargetPath  Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>Cpp\Riosock.pdb</Link>
-      <TargetPath>Riosock.dll</TargetPath>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath  Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.pdb">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>Cpp\Riosock.pdb</Link>
-      <TargetPath>Riosock.pdb</TargetPath>
-    </ContentWithTargetPath>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/csharp/AdapterTest/SocketWrapperTest.cs
+++ b/csharp/AdapterTest/SocketWrapperTest.cs
@@ -57,6 +57,9 @@ namespace AdapterTest
                         
                         Thread.SpinWait(0);
 
+                        // Send more bytes to test ReadByte() do not cause failures
+                        s.Write(bytes, 0, bytesRec);
+
                         // Keep sending to ensure no memory leak
                         var longBytes = Encoding.UTF8.GetBytes(new string('x', 8192));
                         for (int i = 0; i < 1000; i++)
@@ -112,6 +115,10 @@ namespace AdapterTest
                 // Receive echo message
                 var oneByte = s.ReadByte();
                 Assert.AreEqual((byte)1, oneByte);
+
+                // Receive more message to test ReadByte do not cause failures.
+                bytesRec = s.Read(bytes, 0, bytes.Length);
+                Assert.AreNotEqual(0, bytesRec);
 
                 // Keep receiving to ensure no memory leak.
                 while (true)

--- a/csharp/Perf/Microsoft.Spark.CSharp/PerfBenchmark.csproj
+++ b/csharp/Perf/Microsoft.Spark.CSharp/PerfBenchmark.csproj
@@ -11,7 +11,6 @@
     <AssemblyName>SparkCLRPerf</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <CppDll Condition="Exists('..\..\..\cpp\x64')">HasCpp</CppDll>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -48,16 +47,6 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="data\deletionbenchmarktestdata.csv" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(CppDll)' == 'HasCpp' ">
-    <None Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>Cpp\Riosock.dll</Link>
-    </None>
-    <None Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.pdb">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>Cpp\Riosock.pdb</Link>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Adapter\Microsoft.Spark.CSharp\Adapter.csproj">

--- a/csharp/Samples/Microsoft.Spark.CSharp/Samples.csproj
+++ b/csharp/Samples/Microsoft.Spark.CSharp/Samples.csproj
@@ -11,7 +11,6 @@
     <AssemblyName>SparkCLRSamples</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <CppDll Condition="Exists('..\..\..\cpp\x64')">HasCpp</CppDll>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -78,18 +77,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(CppDll)' == 'HasCpp' ">
-    <ContentWithTargetPath Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>Cpp\Riosock.dll</Link>
-      <TargetPath>Riosock.dll</TargetPath>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.pdb">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>Cpp\Riosock.pdb</Link>
-      <TargetPath>Riosock.pdb</TargetPath>
-    </ContentWithTargetPath>
   </ItemGroup>
   <ItemGroup>
     <Content Include="data\csvtestlog.txt">

--- a/csharp/Worker/Microsoft.Spark.CSharp/Worker.csproj
+++ b/csharp/Worker/Microsoft.Spark.CSharp/Worker.csproj
@@ -11,7 +11,6 @@
     <AssemblyName>CSharpWorker</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <CppDll Condition="Exists('..\..\..\cpp\x64')">HasCpp</CppDll>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -50,18 +49,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TaskRunner.cs" />
     <Compile Include="Worker.cs" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(CppDll)' == 'HasCpp' ">
-    <ContentWithTargetPath Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>Cpp\Riosock.dll</Link>
-      <TargetPath>Riosock.dll</TargetPath>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.pdb">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>Cpp\Riosock.pdb</Link>
-      <TargetPath>Riosock.pdb</TargetPath>
-    </ContentWithTargetPath>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Adapter\Microsoft.Spark.CSharp\Adapter.csproj">

--- a/csharp/WorkerTest/WorkerTest.csproj
+++ b/csharp/WorkerTest/WorkerTest.csproj
@@ -16,7 +16,6 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
-    <CppDll Condition="Exists('..\..\cpp\x64')">HasCpp</CppDll>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -76,18 +75,6 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(CppDll)' == 'HasCpp' ">
-    <ContentWithTargetPath Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>Cpp\Riosock.dll</Link>
-      <TargetPath>Riosock.dll</TargetPath>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.pdb">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>Cpp\Riosock.pdb</Link>
-      <TargetPath>Riosock.pdb</TargetPath>
-    </ContentWithTargetPath>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
1. Fix SocketStream.ReadByte() to release unreadable cache
2. Delete unnecessary copy of Riosock.dll in each project file. Because, each project has reference to project Adapter which will automatically copy Riosock.dll.