### PR TITLE
Escaped special characters in build.cmd

### DIFF
--- a/build/Build.cmd
+++ b/build/Build.cmd
@@ -249,7 +249,7 @@ if %CppSkipped% EQU 1 (
     @echo. 
     @echo ===============================================================================================================
     @echo.                                                 !!! Note !!!
-    @echo        Skipped building Mobius C++ component (RIOSock.dll) due to missing VC++ Build Toolset.
+    @echo        Skipped building Mobius C++ component ^(RIOSock.dll^) due to missing VC++ Build Toolset.
     @echo        Mobius uses this component to leverage socket optimization available in Windows    
     @echo        This is an optional component and Mobius will be fully functional even without this component
     @echo        If you want to build this component, enable VC++ project in Visual Studio


### PR DESCRIPTION
This PR tries to fix the build error in AppVeyor.