### PR TITLE
Fix error 10022 in Worker.WriteOutput() caused by RioSocket

### DIFF
--- a/cpp/Riosock/Riosock.h
+++ b/cpp/Riosock/Riosock.h
@@ -52,7 +52,9 @@ extern "C" {
         );
 
     // Registers the method to use for notification behavior.
-    BOOL RIOSOCKAPI RegisterRIONotify();
+    BOOL RIOSOCKAPI RegisterRIONotify(
+        _In_  BOOL  isRecvCq  
+        );
     
     // Registers a specified buffer for use with RIO Socket
     RIO_BUFFERID RIOSOCKAPI RegisterRIOBuffer(
@@ -77,27 +79,30 @@ extern "C" {
 
     // Dequeues RIO results from the I/O completion queue used with RIO socket.
     DWORD RIOSOCKAPI DequeueRIOResults(
+        _In_   BOOL        isRecvCq,
         _Out_  PRIORESULT  rioResults,
         _In_   DWORD       rioResultSize
         );
 
     // Creates a request queue
     RIO_RQ RIOSOCKAPI CreateRIORequestQueue(
-        _In_ SOCKET  socket,
-        _In_ ULONG   maxOutstandingReceive,
-        _In_ ULONG   maxOutstandingSend,
-        _In_ PVOID   socketContext
+        _In_  SOCKET  socket,
+        _In_  ULONG   maxOutstandingReceive,
+        _In_  ULONG   maxOutstandingSend,
+        _In_  PVOID   socketContext
         );
 
     // Resizes a request queue
     BOOL RIOSOCKAPI ResizeRIORequestQueue(
-        _In_ RIO_RQ rq,
-        _In_ DWORD  maxOutstandingReceive,
-        _In_ DWORD  maxOutstandingSend
+        _In_  RIO_RQ rq,
+        _In_  DWORD  maxOutstandingReceive,
+        _In_  DWORD  maxOutstandingSend
         );
 
     // Dequeues an IO completion packet
-    BOOL RIOSOCKAPI GetRIOCompletionStatus();
+    BOOL RIOSOCKAPI GetRIOCompletionStatus(
+        _In_  BOOL  isRecvCq
+        );
 
 #ifdef __cplusplus
 }

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Configuration/ConfigurationService.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Configuration/ConfigurationService.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Spark.CSharp.Configuration
         public const string CSharpSocketTypeEnvName = "spark.mobius.CSharp.socketType";
         public const string CSharpWorkerReadBufferSizeEnvName = "spark.mobius.CSharpWorker.readBufferSize";
         public const string CSharpWorkerWriteBufferSizeEnvName = "spark.mobius.CSharpWorker.writeBufferSize";
+        public const string ExecutorCoresEnvName = "spark.executor.cores";
         public const string SPARKCLR_HOME = "SPARKCLR_HOME";
         public const string SPARK_MASTER = "spark.master";
         public const string CSHARPBACKEND_PORT = "CSHARPBACKEND_PORT";

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Interop/Ipc/JvmBridge.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Interop/Ipc/JvmBridge.cs
@@ -77,6 +77,7 @@ namespace Microsoft.Spark.CSharp.Interop.Ipc
                 using (var s = socket.GetStream())
                 {
                     SerDe.Write(s, overallPayload);
+                    s.Flush();
 
                     var isMethodCallFailed = SerDe.ReadInt(s);
                     //TODO - add boolean instead of int in the backend

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Network/ByteBufChunk.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Network/ByteBufChunk.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
+using Microsoft.Spark.CSharp.Services;
 
 namespace Microsoft.Spark.CSharp.Network
 {
@@ -18,6 +19,7 @@ namespace Microsoft.Spark.CSharp.Network
     /// </summary>
     internal sealed class ByteBufChunk
     {
+        private readonly ILoggerService logger = LoggerServiceFactory.GetLogger(typeof(RioSocketWrapper));
         private readonly Queue<Segment> segmentQueue;
         private readonly int segmentSize;
         private bool disposed;
@@ -286,6 +288,7 @@ namespace Microsoft.Spark.CSharp.Network
                 return;
             }
 
+            logger.LogDebug("Disposing ByteBufChunk [{0}].", ToString());
             if (!IsUnsafe && memory != null)
             {
                 memory = null;

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Network/ISocketWrapper.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Network/ISocketWrapper.cs
@@ -38,6 +38,18 @@ namespace Microsoft.Spark.CSharp.Network
         Stream GetStream();
 
         /// <summary>
+        /// Returns a stream used to receive data only.
+        /// </summary>
+        /// <returns>The underlying Stream instance that be used to receive data</returns>
+        Stream GetInputStream();
+
+        /// <summary>
+        /// Returns a stream used to send data only.
+        /// </summary>
+        /// <returns>The underlying Stream instance that be used to send data</returns>
+        Stream GetOutputStream();
+
+        /// <summary>
         /// Starts listening for incoming connections requests
         /// </summary>
         /// <param name="backlog">The maximum length of the pending connections queue. </param>

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Network/RioSocketWrapper.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Network/RioSocketWrapper.cs
@@ -198,6 +198,24 @@ namespace Microsoft.Spark.CSharp.Network
         }
 
         /// <summary>
+        /// Returns a stream used to receive data only.
+        /// </summary>
+        /// <returns>The underlying Stream instance that be used to receive data</returns>
+        public Stream GetInputStream()
+        {
+            return GetStream();
+        }
+
+        /// <summary>
+        /// Returns a stream used to send data only.
+        /// </summary>
+        /// <returns>The underlying Stream instance that be used to send data</returns>
+        public Stream GetOutputStream()
+        {
+            return GetStream();
+        }
+
+        /// <summary>
         /// Starts listening for incoming connections requests
         /// </summary>
         /// <param name="backlog">The maximum length of the pending connections queue. </param>
@@ -494,7 +512,8 @@ namespace Microsoft.Spark.CSharp.Network
 
             if (status != (int) SocketError.Success)
             {
-                logger.LogError("Socket receive operation failed with error {0}", status);
+                logger.LogError("Socket [{0}] receive operation failed with error code [{1}]",
+                    connectionId, status);
                 context.Data.Release();
                 return;
             }
@@ -560,7 +579,8 @@ namespace Microsoft.Spark.CSharp.Network
             sendStatusQueue.Add(status);
             if (status != (int)SocketError.Success)
             {
-                logger.LogError("Socket send operation failed with error {0}", status);
+                logger.LogError("Socket [{0}] send operation failed with error {1}",
+                    connectionId, status);
                 context.Data.Release();
                 return;
             }

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Network/SaeaSocketWrapper.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Network/SaeaSocketWrapper.cs
@@ -144,6 +144,24 @@ namespace Microsoft.Spark.CSharp.Network
         }
 
         /// <summary>
+        /// Returns a stream used to receive data only.
+        /// </summary>
+        /// <returns>The underlying Stream instance that be used to receive data</returns>
+        public Stream GetInputStream()
+        {
+            return GetStream();
+        }
+
+        /// <summary>
+        /// Returns a stream used to send data only.
+        /// </summary>
+        /// <returns>The underlying Stream instance that be used to send data</returns>
+        public Stream GetOutputStream()
+        {
+            return GetStream();
+        }
+
+        /// <summary>
         /// Starts listening for incoming connections requests
         /// </summary>
         /// <param name="backlog">The maximum length of the pending connections queue. </param>

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/StreamingContextIpcProxy.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/StreamingContextIpcProxy.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Net.Sockets;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading;
@@ -306,7 +305,8 @@ namespace Microsoft.Spark.CSharp.Proxy.Ipc
                                 logger.LogDebug("receive close cmd from Scala side");
                                 break;
                             }
-                            else if (cmd == "callback")
+
+                            if (cmd == "callback")
                             {
                                 int numRDDs = SerDe.ReadInt(s);
                                 var jrdds = new List<JvmObjectReference>();
@@ -343,6 +343,7 @@ namespace Microsoft.Spark.CSharp.Proxy.Ipc
                                     ((Action<double, RDD<dynamic>>)func)(time, rdd);
                                     SerDe.Write(s, (byte)'n');
                                 }
+                                s.Flush();
                             }
                         }
                         catch (Exception e)

--- a/csharp/Adapter/documentation/Microsoft.Spark.CSharp.Adapter.Doc.XML
+++ b/csharp/Adapter/documentation/Microsoft.Spark.CSharp.Adapter.Doc.XML
@@ -227,12 +227,25 @@
             </summary>
             <param name="blocking"></param>
         </member>
+        <member name="T:Microsoft.Spark.CSharp.Core.HadoopConfiguration">
+            <summary>
+            Configuration for Hadoop operations
+            </summary>
+        </member>
         <member name="M:Microsoft.Spark.CSharp.Core.HadoopConfiguration.Set(System.String,System.String)">
             <summary>
-            Sets value to HadoopConfiguration
+            Sets a property value to HadoopConfiguration
             </summary>
             <param name="name">Name of the property</param>
             <param name="value">Value of the property</param>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Core.HadoopConfiguration.Get(System.String,System.String)">
+            <summary>
+            Gets the value of a property from HadoopConfiguration
+            </summary>
+            <param name="name">Name of the property</param>
+            <param name="defaultValue">Default value if the property is not available in the configuration</param>
+            <returns></returns>
         </member>
         <member name="T:Microsoft.Spark.CSharp.Core.Option`1">
             <summary>
@@ -3340,6 +3353,12 @@
             The default chunk order used to calculate chunk size and ensure it is a multiple of a segment size.
             </summary>
         </member>
+        <member name="F:Microsoft.Spark.CSharp.Network.ByteBufPool.TrialsCount">
+            <summary>
+            The trial count of trying to allocate buffer from existing ByteBufChunkList.
+            The 1000 should be enough to trial.
+            </summary>
+        </member>
         <member name="M:Microsoft.Spark.CSharp.Network.ByteBufPool.#ctor(System.Int32,System.Int32,System.Boolean)">
             <summary>
             Initializes a new ByteBufPool instance with a given segment size and chunk order.
@@ -3447,6 +3466,18 @@
             the NetworkStream by yourself. Closing DefaultSocketWrapper does not release the NetworkStream
             </remarks>
         </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.DefaultSocketWrapper.GetInputStream">
+            <summary>
+            Returns a stream used to receive data only.
+            </summary>
+            <returns>The underlying Stream instance that be used to receive data</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.DefaultSocketWrapper.GetOutputStream">
+            <summary>
+            Returns a stream used to send data only.
+            </summary>
+            <returns>The underlying Stream instance that be used to send data</returns>
+        </member>
         <member name="M:Microsoft.Spark.CSharp.Network.DefaultSocketWrapper.Listen(System.Int32)">
             <summary>
             Starts listening for incoming connections requests
@@ -3529,6 +3560,18 @@
             Returns a stream used to send and receive data.
             </summary>
             <returns>The underlying Stream instance that be used to send and receive data</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ISocketWrapper.GetInputStream">
+            <summary>
+            Returns a stream used to receive data only.
+            </summary>
+            <returns>The underlying Stream instance that be used to receive data</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.ISocketWrapper.GetOutputStream">
+            <summary>
+            Returns a stream used to send data only.
+            </summary>
+            <returns>The underlying Stream instance that be used to send data</returns>
         </member>
         <member name="M:Microsoft.Spark.CSharp.Network.ISocketWrapper.Listen(System.Int32)">
             <summary>
@@ -3681,6 +3724,18 @@
             </summary>
             <returns>The underlying Stream instance that be used to send and receive data</returns>
         </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioSocketWrapper.GetInputStream">
+            <summary>
+            Returns a stream used to receive data only.
+            </summary>
+            <returns>The underlying Stream instance that be used to receive data</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.RioSocketWrapper.GetOutputStream">
+            <summary>
+            Returns a stream used to send data only.
+            </summary>
+            <returns>The underlying Stream instance that be used to send data</returns>
+        </member>
         <member name="M:Microsoft.Spark.CSharp.Network.RioSocketWrapper.Listen(System.Int32)">
             <summary>
             Starts listening for incoming connections requests
@@ -3811,6 +3866,18 @@
             </summary>
             <returns>The underlying Stream instance that be used to send and receive data</returns>
         </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.GetInputStream">
+            <summary>
+            Returns a stream used to receive data only.
+            </summary>
+            <returns>The underlying Stream instance that be used to receive data</returns>
+        </member>
+        <member name="M:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.GetOutputStream">
+            <summary>
+            Returns a stream used to send data only.
+            </summary>
+            <returns>The underlying Stream instance that be used to send data</returns>
+        </member>
         <member name="M:Microsoft.Spark.CSharp.Network.SaeaSocketWrapper.Listen(System.Int32)">
             <summary>
             Starts listening for incoming connections requests
@@ -3918,7 +3985,7 @@
         </member>
         <member name="M:Microsoft.Spark.CSharp.Network.SocketStream.Flush">
             <summary>
-            Flushes data from the stream.  This is meaningless for us, so it does nothing.
+            Flushes data in send cache to the stream.
             </summary>
         </member>
         <member name="M:Microsoft.Spark.CSharp.Network.SocketStream.Seek(System.Int64,System.IO.SeekOrigin)">

--- a/csharp/Adapter/documentation/Mobius_API_Documentation.md
+++ b/csharp/Adapter/documentation/Mobius_API_Documentation.md
@@ -499,7 +499,7 @@
         
 ####Methods
 
-<table><tr><th>Name</th><th>Description</th></tr><tr><td><font color="blue">Flush</font></td><td>Flushes data from the stream. This is meaningless for us, so it does nothing.</td></tr><tr><td><font color="blue">Seek</font></td><td>Seeks a specific position in the stream. This method is not supported by the SocketDataStream class.</td></tr><tr><td><font color="blue">SetLength</font></td><td>Sets the length of the stream. This method is not supported by the SocketDataStream class.</td></tr><tr><td><font color="blue">ReadByte</font></td><td>Reads a byte from the stream and advances the position within the stream by one byte, or returns -1 if at the end of the stream.</td></tr><tr><td><font color="blue">Read</font></td><td>Reads data from the stream.</td></tr><tr><td><font color="blue">Write</font></td><td>Writes data to the stream.</td></tr></table>
+<table><tr><th>Name</th><th>Description</th></tr><tr><td><font color="blue">Flush</font></td><td>Flushes data in send cache to the stream.</td></tr><tr><td><font color="blue">Seek</font></td><td>Seeks a specific position in the stream. This method is not supported by the SocketDataStream class.</td></tr><tr><td><font color="blue">SetLength</font></td><td>Sets the length of the stream. This method is not supported by the SocketDataStream class.</td></tr><tr><td><font color="blue">ReadByte</font></td><td>Reads a byte from the stream and advances the position within the stream by one byte, or returns -1 if at the end of the stream.</td></tr><tr><td><font color="blue">Read</font></td><td>Reads data from the stream.</td></tr><tr><td><font color="blue">Write</font></td><td>Writes data to the stream.</td></tr></table>
 
 ---
   

--- a/csharp/AdapterTest/AccumulatorTest.cs
+++ b/csharp/AdapterTest/AccumulatorTest.cs
@@ -46,6 +46,7 @@ namespace AdapterTest
                 {
                     int numUpdates = 0;
                     SerDe.Write(s, numUpdates);
+                    s.Flush();
                 }
             }
             catch

--- a/csharp/AdapterTest/ByteBufPoolTest.cs
+++ b/csharp/AdapterTest/ByteBufPoolTest.cs
@@ -43,14 +43,14 @@ namespace AdapterTest
             Assert.AreEqual(0, chunkNumbers[5]); // The number of chunks in 100% usage queue should be 0 at beginning.
 
             var bufs = new List<ByteBuf>();
-            for (var i = 0; i < 257; i++)
+            for (var i = 0; i < 4097; i++)
             {
                 var byteBuf = bufPool.Allocate();
                 bufs.Add(byteBuf);
             }
 
-            var firstChunk = bufs[255].ByteBufChunk;
-            var secondChunk = bufs[256].ByteBufChunk;
+            var firstChunk = bufs[4095].ByteBufChunk;
+            var secondChunk = bufs[4096].ByteBufChunk;
 
             // Verify the buffer pool got grown.
             Assert.AreNotSame(firstChunk, secondChunk);
@@ -117,14 +117,14 @@ namespace AdapterTest
             }
 
             var bufs = new List<ByteBuf>();
-            for (var i = 0; i < 257; i++)
+            for (var i = 0; i < 4097; i++)
             {
                 var byteBuf = unsafeBufPool.Allocate();
                 bufs.Add(byteBuf);
             }
 
-            var firstChunk = bufs[255].ByteBufChunk;
-            var secondChunk = bufs[256].ByteBufChunk;
+            var firstChunk = bufs[4095].ByteBufChunk;
+            var secondChunk = bufs[4096].ByteBufChunk;
 
             // Verify the buffer pool got grown.
             Assert.AreNotSame(firstChunk, secondChunk);

--- a/csharp/AdapterTest/Mocks/MockSparkContextProxy.cs
+++ b/csharp/AdapterTest/Mocks/MockSparkContextProxy.cs
@@ -219,6 +219,7 @@ namespace AdapterTest.Mocks
                         SerDe.Write(ns, item.Length);
                         SerDe.Write(ns, item);
                     }
+                    ns.Flush();
                 }
             });
             return (listener.LocalEndPoint as IPEndPoint).Port;

--- a/csharp/AdapterTest/TestWithMoqDemo.cs
+++ b/csharp/AdapterTest/TestWithMoqDemo.cs
@@ -77,6 +77,7 @@ namespace AdapterTest
                             SerDe.Write(ns, buffer.Length);
                             SerDe.Write(ns, buffer);
                         }
+                        ns.Flush();
                     }
                 });
                 return (listener.LocalEndPoint as IPEndPoint).Port;

--- a/csharp/Worker/Microsoft.Spark.CSharp/MultiThreadWorker.cs
+++ b/csharp/Worker/Microsoft.Spark.CSharp/MultiThreadWorker.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Net;
 using System.Collections.Concurrent;
 using System.Linq;
-using System.Net.Sockets;
 using System.Threading;
 using Microsoft.Spark.CSharp.Interop.Ipc;
 using Microsoft.Spark.CSharp.Network;
@@ -18,7 +17,7 @@ namespace Microsoft.Spark.CSharp
     /// <summary>
     /// The C# worker process is shared by multiple JVM Tasks. A daemon thread listens to the server socket
     /// and establish new TCP connection. Multiple work threads pick up the TCP connection, use this connection
-    /// to commuicate with JVM and do the actual work.
+    /// to communicate with JVM and do the actual work.
     /// </summary>
     public class MultiThreadWorker
     {
@@ -69,7 +68,7 @@ namespace Microsoft.Spark.CSharp
 
                     if (length != sizeof(int))
                     {
-                        logger.LogError(string.Format("read error, length: {0}, will exit", length));
+                        logger.LogError("Read error, length: {0}, will exit", length);
                         Environment.Exit(-1);
                     }
                     int trId = SerDe.ToInt(bytes);
@@ -81,7 +80,7 @@ namespace Microsoft.Spark.CSharp
                     }
                     else
                     {
-                        logger.LogInfo(string.Format("try to stop taskRunner [{0}]", trId));
+                        logger.LogInfo("try to stop taskRunner [{0}]", trId);
                         if (taskRunnerRegistry.ContainsKey(trId))
                         {
                             TaskRunner tr = taskRunnerRegistry[trId];
@@ -89,7 +88,7 @@ namespace Microsoft.Spark.CSharp
                         }
                         else
                         {
-                            logger.LogWarn(string.Format("can't find taskRunner [{0}] in TaskRunnerRegistery. Maybe it has exited already?", trId));
+                            logger.LogWarn("can't find taskRunner [{0}] in TaskRunnerRegistery. Maybe it has exited already?", trId);
                         }
                     }
                 }
@@ -177,9 +176,9 @@ namespace Microsoft.Spark.CSharp
                         tr.Run();
 
                         // remove it from registry
-                        int trId = tr.trId;
+                        var trId = tr.TaskId;
                         TaskRunner tmp;
-                        taskRunnerRegistry.TryRemove(tr.trId, out tmp);
+                        taskRunnerRegistry.TryRemove(trId, out tmp);
                     }
                 }
             }

--- a/csharp/Worker/Microsoft.Spark.CSharp/Worker.cs
+++ b/csharp/Worker/Microsoft.Spark.CSharp/Worker.cs
@@ -75,8 +75,8 @@ namespace Microsoft.Spark.CSharp
             // can't initialize logger early because in MultiThreadWorker mode, JVM will read C#'s stdout via
             // pipe. When initialize logger, some unwanted info will be flushed to stdout. But we can still
             // use stderr
-            Console.Error.WriteLine("input args: [{0}] SocketWrapper: [{1}]",
-                string.Join(" ", args), SocketFactory.SocketWrapperType);
+            Console.Error.WriteLine("CSharpWorker [{0}]: Input args [{1}] SocketWrapper [{2}]",
+                Process.GetCurrentProcess().Id, string.Join(" ", args), SocketFactory.SocketWrapperType);
 
             if (args.Length != 2)
             {
@@ -343,12 +343,20 @@ namespace Microsoft.Spark.CSharp
                         continue;
                     }
 
-                    WriteOutput(outputStream, serializerMode, message, formatter);
+                    try
+                    {
+                        WriteOutput(outputStream, serializerMode, message, formatter);
+                    }
+                    catch (Exception)
+                    {
+                        logger.LogError("WriteOutput() failed at iteration {0}", count);
+                        throw;
+                    }
                     count++;
                     funcProcessWatch.Start();
                 }
 
-                logger.LogDebug("Output entries count: " + count);
+                logger.LogInfo("Output entries count: " + count);
                 logger.LogDebug("Null messages count: " + nullMessageCount);
 
                 //if profiler:

--- a/csharp/WorkerTest/WorkerTest.cs
+++ b/csharp/WorkerTest/WorkerTest.cs
@@ -358,6 +358,7 @@ namespace WorkerTest
                     WritePayloadHeaderToWorker(s);
                     SerDe.Write(s, command.Length);
                     s.Write(command, 0, command.Length/2);
+                    s.Flush();
                 }
 
                 AssertWorker(worker, 0, "System.ArgumentException: Incomplete bytes read: ");

--- a/scala/src/main/org/apache/spark/api/csharp/CSharpRDD.scala
+++ b/scala/src/main/org/apache/spark/api/csharp/CSharpRDD.scala
@@ -85,6 +85,10 @@ class CSharpRDD(
         CSharpRDD.csharpWorkerWriteBufferSize.toString)
     }
 
+    if (CSharpRDD.executorCores >= 0) {
+      envVars.put("spark.executor.cores", CSharpRDD.executorCores.toString)
+    }
+
     logInfo("Env vars: " + envVars.asScala.mkString(", "))
 
     val runner = new PythonRunner(
@@ -221,6 +225,8 @@ object CSharpRDD {
   var csharpWorkerReadBufferSize: Int = SparkEnv.get.conf.getInt("spark.mobius.CSharpWorker.readBufferSize", -1)
   // Buffer size in bytes for operation of writing data to JVM process
   var csharpWorkerWriteBufferSize: Int = SparkEnv.get.conf.getInt("spark.mobius.CSharpWorker.writeBufferSize", -1)
+  // Cores per executor
+  var executorCores: Int = SparkEnv.get.conf.getInt("spark.executor.cores", -1)
 
   def createRDDFromArray(
       sc: SparkContext,


### PR DESCRIPTION
There are random failures on Worker.WriteOutput() with socket error 10022 (An invalid argument was supplied). The reason of the error is because the RioSocketWrapper pass the managed buffer to native buffer and call native code to send the data too many. 

This change is to modify SocketStream.Write with a send data cache, so that to reduce the frequency of calling Riosocket send operation.  