### PR TITLE
(Branch-1.6) Improve Worker logging to make CSharpWorkerFunc stacktrace clear

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Core/PipelinedRDD.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Core/PipelinedRDD.cs
@@ -116,13 +116,14 @@ namespace Microsoft.Spark.CSharp.Core
         public CSharpWorkerFunc(Func<int, IEnumerable<dynamic>, IEnumerable<dynamic>> func)
         {
             this.func = func;
-            stackTrace = new StackTrace(true).ToString();
+            stackTrace = new StackTrace(true).ToString().Replace("   at ", "   [STACK] ");
         }
 
         public CSharpWorkerFunc(Func<int, IEnumerable<dynamic>, IEnumerable<dynamic>> func, string innerStackTrace)
+            : this(func)
         {
-            this.func = func;
-            stackTrace = new StackTrace(true).ToString() + "\nInner stack trace ...\n" + innerStackTrace;
+            stackTrace += string.Format("   [STACK] --- Inner stack trace: ---{0}{1}",
+                Environment.NewLine, innerStackTrace.Replace("   at ", "   [STACK] "));
         }
 
         public Func<int, IEnumerable<dynamic>, IEnumerable<dynamic>> Func

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Services/DefaultLoggerService.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Services/DefaultLoggerService.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.Spark.CSharp.Services
 {
@@ -12,7 +8,20 @@ namespace Microsoft.Spark.CSharp.Services
     /// </summary>
     public class DefaultLoggerService : ILoggerService
     {
-        internal readonly static DefaultLoggerService Instance = new DefaultLoggerService(typeof (Type));
+        internal static readonly DefaultLoggerService Instance = new DefaultLoggerService(typeof (Type));
+        private readonly Type type;
+
+        private DefaultLoggerService(Type t)
+        {
+            type = t;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether logging is enabled for the Debug level.
+        /// Always return true for the DefaultLoggerService object.
+        /// </summary>
+        public bool IsDebugEnabled { get { return true; } }
+
         /// <summary>
         /// Get an instance of ILoggerService by a given type of logger
         /// </summary>
@@ -21,12 +30,6 @@ namespace Microsoft.Spark.CSharp.Services
         public ILoggerService GetLoggerInstance(Type type)
         {
             return new DefaultLoggerService(type);
-        }
-
-        private readonly Type type;
-        private DefaultLoggerService(Type t)
-        {
-            type = t;
         }
         
         /// <summary>

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Services/ILoggerService.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Services/ILoggerService.cs
@@ -8,6 +8,11 @@ namespace Microsoft.Spark.CSharp.Services
     public interface ILoggerService
     {
         /// <summary>
+        /// Gets a value indicating whether logging is enabled for the Debug level.
+        /// </summary>
+        bool IsDebugEnabled { get; }
+
+        /// <summary>
         /// Get an instance of ILoggerService by a given type of logger
         /// </summary>
         /// <param name="type">The type of a logger to return</param>

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Services/Log4NetLoggerService.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Services/Log4NetLoggerService.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
 using System.Diagnostics;
-using System.Threading.Tasks;
 using log4net;
 using log4net.Config;
 
@@ -35,7 +31,15 @@ namespace Microsoft.Spark.CSharp.Services
         public Log4NetLoggerService(Type type)
         {
             logger = LogManager.GetLogger(type);
-            log4net.GlobalContext.Properties["pid"] = Process.GetCurrentProcess().Id;
+            GlobalContext.Properties["pid"] = Process.GetCurrentProcess().Id;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether logging is enabled for the Debug level.
+        /// </summary>
+        public bool IsDebugEnabled
+        {
+            get { return logger.IsDebugEnabled; }
         }
 
         /// <summary>
@@ -139,7 +143,6 @@ namespace Microsoft.Spark.CSharp.Services
         /// <param name="e">The exception to be logged</param>
         public void LogException(Exception e)
         {
-            
             if (e.GetType() != typeof(AggregateException))
             {
                 logger.Error(e.Message);

--- a/csharp/Adapter/documentation/Microsoft.Spark.CSharp.Adapter.Doc.XML
+++ b/csharp/Adapter/documentation/Microsoft.Spark.CSharp.Adapter.Doc.XML
@@ -4272,6 +4272,12 @@
             Right now it just prints out the messages to Console
             </summary>
         </member>
+        <member name="P:Microsoft.Spark.CSharp.Services.DefaultLoggerService.IsDebugEnabled">
+            <summary>
+            Gets a value indicating whether logging is enabled for the Debug level.
+            Always return true for the DefaultLoggerService object.
+            </summary>
+        </member>
         <member name="M:Microsoft.Spark.CSharp.Services.DefaultLoggerService.GetLoggerInstance(System.Type)">
             <summary>
             Get an instance of ILoggerService by a given type of logger
@@ -4353,6 +4359,11 @@
         <member name="T:Microsoft.Spark.CSharp.Services.ILoggerService">
             <summary>
             Defines a logger what be used in service
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Services.ILoggerService.IsDebugEnabled">
+            <summary>
+            Gets a value indicating whether logging is enabled for the Debug level.
             </summary>
         </member>
         <member name="M:Microsoft.Spark.CSharp.Services.ILoggerService.GetLoggerInstance(System.Type)">
@@ -4448,6 +4459,11 @@
             Initializes a instance of Log4NetLoggerService with a specific type.
             </summary>
             <param name="type">The type of the logger</param>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Services.Log4NetLoggerService.IsDebugEnabled">
+            <summary>
+            Gets a value indicating whether logging is enabled for the Debug level.
+            </summary>
         </member>
         <member name="M:Microsoft.Spark.CSharp.Services.Log4NetLoggerService.LogDebug(System.String)">
             <summary>


### PR DESCRIPTION
Currently, the CSharpWorkerFunc stacktrace looks like the same with exception stack trace. It is really confusing to users. This change is to improve CSharpWorker logging to make CSharpWorkerFunc stacktrace looks like below:

[2016-08-31T18:42:36.1260640Z] [HEBIN-Z420] [Debug] [Worker]
------------------------ Printing stack trace of workerFunc for ** debugging ** ------------------------------
   [STACK] Microsoft.Spark.CSharp.Core.CSharpWorkerFunc..ctor(Func`3 func)
   [STACK] Microsoft.Spark.CSharp.Core.CSharpWorkerFunc..ctor(Func`3 func, String innerStackTrace)
   [STACK] Microsoft.Spark.CSharp.Core.PipelinedRDD`1.MapPartitionsWithIndex[U1](Func`3 newFunc, Boolean preservesPartitioningParam)
   [STACK] SelectionSensorsAgg.Program.<>c.<Main>b__35_6(RDD`1 rdd) in E:\GitSrc\Discsel\private\indexgen\DiscoverySelection\Spark\SensorDelta\SelectionSensorsAgg\Program.cs:line 245
   [STACK] System.Linq.Enumerable.<>c__DisplayClass7_0`3.<CombineSelectors>b__0(TSource x)
   [STACK] System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   [STACK] System.Linq.Enumerable.First[TSource](IEnumerable`1 source)
   [STACK] Microsoft.Spark.CSharp.Proxy.Ipc.SparkContextIpcProxy.Union(IEnumerable`1 rdds)
   [STACK] Microsoft.Spark.CSharp.Core.SparkContext.Union[T](IEnumerable`1 rdds)
   [STACK] SelectionSensorsAgg.Program.Main(String[] args) in E:\GitSrc\Discsel\private\indexgen\DiscoverySelection\Spark\SensorDelta\SelectionSensorsAgg\Program.cs:line 245
   [STACK] System.AppDomain._nExecuteAssembly(RuntimeAssembly assembly, String[] args)
   [STACK] System.AppDomain.ExecuteAssembly(String assemblyFile, Evidence assemblySecurity, String[] args)
   [STACK] Microsoft.VisualStudio.HostingProcess.HostProc.RunUsersAssembly()
   [STACK] System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   [STACK] System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   [STACK] System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   [STACK] System.Threading.ThreadHelper.ThreadStart()
   [STACK] --- Inner stack trace: ---
   [STACK] Microsoft.Spark.CSharp.Core.CSharpWorkerFunc..ctor(Func`3 func)
   [STACK] Microsoft.Spark.CSharp.Core.CSharpWorkerFunc..ctor(Func`3 func, String innerStackTrace)
   [STACK] Microsoft.Spark.CSharp.Core.PipelinedRDD`1.MapPartitionsWithIndex[U1](Func`3 newFunc, Boolean preservesPartitioningParam)
   [STACK] Microsoft.Spark.CSharp.ScopeWrapper.ScopeWrapper.<>c__DisplayClass17_0.<Output>b__0(RDD`1 rdd) in E:\GitSrc\Discsel\private\indexgen\DiscoverySelection\Spark\ScopeWrapper\ScopeWrapper.cs:line 193
   [STACK] System.Linq.Enumerable.<>c__DisplayClass7_0`3.<CombineSelectors>b__0(TSource x)
   [STACK] System.Linq.Enumerable.<>c__DisplayClass7_0`3.<CombineSelectors>b__0(TSource x)
   [STACK] System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   [STACK] System.Linq.Enumerable.First[TSource](IEnumerable`1 source)
   [STACK] Microsoft.Spark.CSharp.Proxy.Ipc.SparkContextIpcProxy.Union(IEnumerable`1 rdds)
   [STACK] Microsoft.Spark.CSharp.Core.SparkContext.Union[T](IEnumerable`1 rdds)
   [STACK] SelectionSensorsAgg.Program.Main(String[] args) in E:\GitSrc\Discsel\private\indexgen\DiscoverySelection\Spark\SensorDelta\SelectionSensorsAgg\Program.cs:line 245
   [STACK] System.AppDomain._nExecuteAssembly(RuntimeAssembly assembly, String[] args)
   [STACK] System.AppDomain.ExecuteAssembly(String assemblyFile, Evidence assemblySecurity, String[] args)
   [STACK] Microsoft.VisualStudio.HostingProcess.HostProc.RunUsersAssembly()
   [STACK] System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   [STACK] System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   [STACK] System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   [STACK] System.Threading.ThreadHelper.ThreadStart()
--------------------------------------------------------------------------------------------------------------