### PR TITLE
Windows path separators used in run-samples.sh

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -22,6 +22,41 @@ fi
 [ ! -d "$SPARKCLR_HOME/lib" ] && mkdir "$SPARKCLR_HOME/lib"
 [ ! -d "$SPARKCLR_HOME/samples" ] && mkdir "$SPARKCLR_HOME/samples"
 [ ! -d "$SPARKCLR_HOME/scripts" ] && mkdir "$SPARKCLR_HOME/scripts"
+[ ! -d "$SPARKCLR_HOME/dependencies" ] && mkdir "$SPARKCLR_HOME/dependencies"
+
+echo "Download Mobius external dependencies"
+pushd "$SPARKCLR_HOME/dependencies"
+
+download_dependency() {
+  LINK=$1
+  JAR=$2
+
+  if [ ! -e $JAR ];
+  then
+    wget $LINK -O $JAR
+
+    if [ ! -e $JAR ];
+    then
+      echo "Cannot download external dependency $JAR from $LINK"
+      popd
+      exit 1
+    fi
+  fi
+}
+
+SPARK_CSV_LINK="http://search.maven.org/remotecontent?filepath=com/databricks/spark-csv_2.10/1.3.0/spark-csv_2.10-1.3.0.jar"
+SPARK_CSV_JAR="spark-csv_2.10-1.3.0.jar"
+download_dependency $SPARK_CSV_LINK $SPARK_CSV_JAR
+
+COMMONS_CSV_LINK="http://search.maven.org/remotecontent?filepath=org/apache/commons/commons-csv/1.1/commons-csv-1.1.jar"
+COMMONS_CSV_JAR="commons-csv-1.1.jar"
+download_dependency $COMMONS_CSV_LINK $COMMONS_CSV_JAR
+
+SPARK_STREAMING_KAFKA_LINK="http://search.maven.org/remotecontent?filepath=org/apache/spark/spark-streaming-kafka-0-8-assembly_2.11/2.0.0/spark-streaming-kafka-0-8-assembly_2.11-2.0.0.jar"
+SPARK_STREAMING_KAFKA_JAR="spark-streaming-kafka-0-8-assembly_2.11-2.0.0.jar"
+download_dependency $SPARK_STREAMING_KAFKA_LINK $SPARK_STREAMING_KAFKA_JAR
+
+popd
 
 echo "Assemble Mobius Scala components"
 pushd "$FWDIR/../scala"
@@ -36,7 +71,7 @@ mvn clean -q
 # build the package
 mvn package -Puber-jar -q
 
-if [ $? -ne 0 ]
+if [ $? -ne 0 ];
 then
 	echo "Build Mobius Scala components failed, stop building."
 	popd

--- a/build/localmode/run-samples.sh
+++ b/build/localmode/run-samples.sh
@@ -73,9 +73,9 @@ fi
 
 export SPARKCLR_HOME="$FWDIR/../runtime"
 # spark-csv package and its depenedency are required for DataFrame operations in Mobius
-export SPARKCLR_EXT_PATH="$SPARKCLR_HOME\dependencies"
-export SPARKCSV_JAR1PATH="$SPARKCLR_EXT_PATH\spark-csv_2.10-1.3.0.jar"
-export SPARKCSV_JAR2PATH="$SPARKCLR_EXT_PATH\commons-csv-1.1.jar"
+export SPARKCLR_EXT_PATH="$SPARKCLR_HOME/dependencies"
+export SPARKCSV_JAR1PATH="$SPARKCLR_EXT_PATH/spark-csv_2.10-1.3.0.jar"
+export SPARKCSV_JAR2PATH="$SPARKCLR_EXT_PATH/commons-csv-1.1.jar"
 export SPARKCLR_EXT_JARS="$SPARKCSV_JAR1PATH,$SPARKCSV_JAR2PATH"
 
 # run-samples.sh is in local mode, should not load Hadoop or Yarn cluster config. Disable Hadoop/Yarn conf dir.


### PR DESCRIPTION
This is a unix-specific shell script and should only use unix path separators. When executed on a unix system, the resulting path names are incorrect. For example:

`[run-samples.sh]
SPARKCLR_EXT_JARS=/home/dwnichols/Mobius/build/localmode/../runtime\dependencies\spark-csv_2.10-1.3.0.jar,/home/dwnichols/Mobius/build/localmode/../runtime\dependencies\commons-csv-1.1.jar`

