### PR TITLE
Add Python version performance benchmark test; Add usage and example and RIOSocket option support for C# version benchmark; Update Scala version benchmark; Update csv package version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.class
 *.dll
 *.exe
+*.pyc
 
 # Packages #
 ############

--- a/build/build.sh
+++ b/build/build.sh
@@ -30,12 +30,12 @@ download_dependency() {
   fi
 }
 
-SPARK_CSV_LINK="http://search.maven.org/remotecontent?filepath=com/databricks/spark-csv_2.10/1.3.0/spark-csv_2.10-1.3.0.jar"
-SPARK_CSV_JAR="spark-csv_2.10-1.3.0.jar"
+SPARK_CSV_LINK="http://search.maven.org/remotecontent?filepath=com/databricks/spark-csv_2.10/1.4.0/spark-csv_2.10-1.4.0.jar"
+SPARK_CSV_JAR="spark-csv_2.10-1.4.0.jar"
 download_dependency $SPARK_CSV_LINK $SPARK_CSV_JAR
 
-COMMONS_CSV_LINK="http://search.maven.org/remotecontent?filepath=org/apache/commons/commons-csv/1.1/commons-csv-1.1.jar"
-COMMONS_CSV_JAR="commons-csv-1.1.jar"
+COMMONS_CSV_LINK="http://search.maven.org/remotecontent?filepath=org/apache/commons/commons-csv/1.4/commons-csv-1.4.jar"
+COMMONS_CSV_JAR="commons-csv-1.4.jar"
 download_dependency $COMMONS_CSV_LINK $COMMONS_CSV_JAR
 
 SPARK_STREAMING_KAFKA_LINK="http://search.maven.org/remotecontent?filepath=org/apache/spark/spark-streaming-kafka-0-8-assembly_2.11/2.0.0/spark-streaming-kafka-0-8-assembly_2.11-2.0.0.jar"

--- a/build/localmode/RunSamples.cmd
+++ b/build/localmode/RunSamples.cmd
@@ -68,8 +68,8 @@ set SPARKCLR_HOME=%CMDHOME%\..\runtime
 
 @rem spark-csv package and its depenedency are required for DataFrame operations in Mobius
 set SPARKCLR_EXT_PATH=%SPARKCLR_HOME%\dependencies
-set SPARKCSV_JAR1PATH=%SPARKCLR_EXT_PATH%\spark-csv_2.10-1.3.0.jar
-set SPARKCSV_JAR2PATH=%SPARKCLR_EXT_PATH%\commons-csv-1.1.jar
+set SPARKCSV_JAR1PATH=%SPARKCLR_EXT_PATH%\spark-csv_2.10-1.4.0.jar
+set SPARKCSV_JAR2PATH=%SPARKCLR_EXT_PATH%\commons-csv-1.4.jar
 set SPARKCLR_EXT_JARS=%SPARKCSV_JAR1PATH%,%SPARKCSV_JAR2PATH%
 
 @rem RunSamples.cmd is in local mode, should not load Hadoop or Yarn cluster config. Disable Hadoop/Yarn conf dir.

--- a/build/localmode/downloadtools.ps1
+++ b/build/localmode/downloadtools.ps1
@@ -347,14 +347,14 @@ function Download-ExternalDependencies
 	
 	$readMeStream.WriteLine("------------ Dependencies for CSV parsing in Mobius DataFrame API -----------------------------")
 	# Downloading spark-csv package and its depenency. These packages are required for DataFrame operations in Mobius
-	$url = "http://search.maven.org/remotecontent?filepath=com/databricks/spark-csv_2.10/1.3.0/spark-csv_2.10-1.3.0.jar"
-    $output="$scriptDir\..\dependencies\spark-csv_2.10-1.3.0.jar"
+	$url = "http://search.maven.org/remotecontent?filepath=com/databricks/spark-csv_2.10/1.4.0/spark-csv_2.10-1.4.0.jar"
+    $output="$scriptDir\..\dependencies\spark-csv_2.10-1.4.0.jar"
     Download-File $url $output
 	Write-Output "[downloadtools.Download-ExternalDependencies] Downloading $url to $scriptDir\..\dependencies"
 	$readMeStream.WriteLine("$url")
 	
-	$url = "http://search.maven.org/remotecontent?filepath=org/apache/commons/commons-csv/1.1/commons-csv-1.1.jar"
-	$output="$scriptDir\..\dependencies\commons-csv-1.1.jar"
+	$url = "http://search.maven.org/remotecontent?filepath=org/apache/commons/commons-csv/1.4/commons-csv-1.4.jar"
+	$output="$scriptDir\..\dependencies\commons-csv-1.4.jar"
 	Download-File $url $output
     Write-Output "[downloadtools.Download-ExternalDependencies] Downloading $url to $scriptDir\..\dependencies"
 	$readMeStream.WriteLine("$url")

--- a/build/localmode/run-samples.sh
+++ b/build/localmode/run-samples.sh
@@ -74,8 +74,8 @@ fi
 export SPARKCLR_HOME="$FWDIR/../runtime"
 # spark-csv package and its depenedency are required for DataFrame operations in Mobius
 export SPARKCLR_EXT_PATH="$SPARKCLR_HOME/dependencies"
-export SPARKCSV_JAR1PATH="$SPARKCLR_EXT_PATH/spark-csv_2.10-1.3.0.jar"
-export SPARKCSV_JAR2PATH="$SPARKCLR_EXT_PATH/commons-csv-1.1.jar"
+export SPARKCSV_JAR1PATH="$SPARKCLR_EXT_PATH/spark-csv_2.10-1.4.0.jar"
+export SPARKCSV_JAR2PATH="$SPARKCLR_EXT_PATH/commons-csv-1.4.jar"
 export SPARKCLR_EXT_JARS="$SPARKCSV_JAR1PATH,$SPARKCSV_JAR2PATH"
 
 # run-samples.sh is in local mode, should not load Hadoop or Yarn cluster config. Disable Hadoop/Yarn conf dir.

--- a/csharp/Perf/Microsoft.Spark.CSharp/FreebaseDeletionsBenchmark.cs
+++ b/csharp/Perf/Microsoft.Spark.CSharp/FreebaseDeletionsBenchmark.cs
@@ -101,13 +101,13 @@ namespace Microsoft.Spark.CSharp.PerfBenchmark
             stopwatch.Restart();
 
             var rows = PerfBenchmark.SqlContext.TextFile(args[2]);
-            var filtered = rows.Filter("C1 = C3");
-            var aggregated = filtered.GroupBy("C1").Agg(new Dictionary<string, string> { { "C1", "count" } });
+            var filtered = rows.Filter("_c1 = _c3");
+            var aggregated = filtered.GroupBy("_c1").Agg(new Dictionary<string, string> { { "_c1", "count" } });
             aggregated.RegisterTempTable("freebasedeletions");
-            var max = PerfBenchmark.SqlContext.Sql("select max(`count(C1)`) from freebasedeletions");
+            var max = PerfBenchmark.SqlContext.Sql("select max(`count(_c1)`) from freebasedeletions");
             var maxArray = max.Collect();
             var maxValue = maxArray.First();
-            var maxDeletions = PerfBenchmark.SqlContext.Sql("select * from freebasedeletions where `count(C1)` = " + maxValue.Get(0));
+            var maxDeletions = PerfBenchmark.SqlContext.Sql("select * from freebasedeletions where `count(_c1)` = " + maxValue.Get(0));
             maxDeletions.Show();
             //TODO - add perf suite for subquery
 

--- a/csharp/Perf/Microsoft.Spark.CSharp/FreebaseDeletionsBenchmark.cs
+++ b/csharp/Perf/Microsoft.Spark.CSharp/FreebaseDeletionsBenchmark.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Spark.CSharp.PerfBenchmark
     /// <summary>
     /// Perf benchmark that users Freebase deletions data
     /// This data is licensed under CC-BY license (http://creativecommons.org/licenses/by/2.5)
-    /// Data is available for download at https://developers.google.com/freebase/data)
+    /// Data is available for downloading : "Freebase Deleted Triples" at https://developers.google.com/freebase
     /// Data format - CSV, size - 8 GB uncompressed
     /// Columns in the dataset are
     ///     1. creation_timestamp (Unix epoch time in milliseconds)
@@ -55,7 +55,7 @@ namespace Microsoft.Spark.CSharp.PerfBenchmark
             var lines = PerfBenchmark.SparkContext.TextFile(filePath);
             var parsedRows = lines.Map(s =>
             {
-                var columns = s.Split(new[] {','});
+                var columns = s.Split(new[] { ',' });
 
                 //data has some bad records - use bool flag to indicate corrupt rows
                 if (columns.Length > 4)
@@ -75,7 +75,7 @@ namespace Microsoft.Spark.CSharp.PerfBenchmark
                 else
                     return kvp2;
             });
-            
+
             stopwatch.Stop();
             PerfBenchmark.ExecutionTimeList.Add(stopwatch.Elapsed);
 
@@ -114,9 +114,9 @@ namespace Microsoft.Spark.CSharp.PerfBenchmark
             stopwatch.Stop();
             PerfBenchmark.ExecutionTimeList.Add(stopwatch.Elapsed);
             Console.WriteLine("User with max deletions & count of deletions is listed above. Time elapsed {0}", stopwatch.Elapsed);
-            
+
         }
-        
-       
+
+
     }
 }

--- a/csharp/Perf/Microsoft.Spark.CSharp/PerfBenchmark.csproj
+++ b/csharp/Perf/Microsoft.Spark.CSharp/PerfBenchmark.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>SparkCLRPerf</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <CppDll Condition="Exists('..\..\..\cpp\x64')">HasCpp</CppDll>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -48,6 +49,16 @@
     </None>
     <None Include="data\deletionbenchmarktestdata.csv" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(CppDll)' == 'HasCpp' ">
+    <None Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Cpp\Riosock.dll</Link>
+    </None>
+    <None Include="$(SolutionDir)..\cpp\x64\$(ConfigurationName)\Riosock.pdb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Cpp\Riosock.pdb</Link>
+    </None>
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Adapter\Microsoft.Spark.CSharp\Adapter.csproj">
       <Project>{ce999a96-f42b-4e80-b208-709d7f49a77c}</Project>
@@ -60,6 +71,10 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">copy /y $(ProjectDir)..\..\..\csharp\Worker\Microsoft.Spark.CSharp\bin\$(ConfigurationName)\CSharpWorker.* $(TargetDir)</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(OS)' == 'Unix' ">cp -uv $(ProjectDir)../../../csharp/Worker/Microsoft.Spark.CSharp/bin/$(ConfigurationName)/CSharpWorker.* $(TargetDir)</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/csharp/Perf/Microsoft.Spark.CSharp/Program.cs
+++ b/csharp/Perf/Microsoft.Spark.CSharp/Program.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Spark.CSharp.Core;
 using Microsoft.Spark.CSharp.Sql;
@@ -24,6 +25,17 @@ namespace Microsoft.Spark.CSharp.PerfBenchmark
 
         public static void Main(string[] args)
         {
+            if (args.Length != 3)
+            {
+                var exe = System.Reflection.Assembly.GetEntryAssembly().Location;
+                Console.WriteLine(@"Usage   : {0}  spark-local-dir   run-count  data-path", exe);
+                Console.WriteLine(@"Example : {0}  D:\Temp\perfTest  10         hdfs:///perfdata/freebasedeletions/*", exe);
+                Console.WriteLine(@"Example : {0}  D:\Temp\perfTest  1          hdfs:///perf/data/deletions/deletions.csv-00000-of-00020", exe);
+                Console.WriteLine(@"Example : {0}  D:\Temp\perfTest  1          file:///d:/mobius/deletions/*", exe);
+                Console.WriteLine(@"Example : {0}  D:\Temp\perfTest  1          d:\mobius\deletions", exe);
+                return;
+            }
+
             Console.WriteLine("Arguments are {0}", string.Join(",", args));
 
             InitializeSparkContext(args);
@@ -51,7 +63,7 @@ namespace Microsoft.Spark.CSharp.PerfBenchmark
         {
             var perfSuites = Assembly.GetEntryAssembly().GetTypes()
                 .SelectMany(type => type.GetMethods(BindingFlags.NonPublic | BindingFlags.Static))
-                .Where(method => method.GetCustomAttributes(typeof (PerfSuiteAttribute), false).Length > 0)
+                .Where(method => method.GetCustomAttributes(typeof(PerfSuiteAttribute), false).Length > 0)
                 .OrderByDescending(method => method.Name);
 
             foreach (var perfSuite in perfSuites)
@@ -75,42 +87,46 @@ namespace Microsoft.Spark.CSharp.PerfBenchmark
         internal static void ReportResult()
         {
             Console.WriteLine("** Printing results of the perf run (C#) **");
-
+            var allMedianCosts = new SortedDictionary<string, long>();
             foreach (var perfResultItem in PerfResults)
             {
                 var perfResult = perfResultItem.Value;
 
-                var runTimeInSeconds = perfResult.Select(x => (long) x.TotalSeconds);
+                var runTimeInSeconds = perfResult.Select(x => (long)x.TotalSeconds);
                 //multiple enumeration happening - ignoring that for now
                 var max = runTimeInSeconds.Max();
                 var min = runTimeInSeconds.Min();
-                var avg = (long) runTimeInSeconds.Average();
+                var avg = (long)runTimeInSeconds.Average();
                 var median = GetMedianValue(runTimeInSeconds);
                 Console.WriteLine(
                     "** Execution time for {0} in seconds. Min={1}, Max={2}, Average={3}, Median={4}, Number of runs={5}, Individual execution duration=[{6}] **",
                     perfResultItem.Key, min, max, avg, median, runTimeInSeconds.Count(), string.Join(", ", runTimeInSeconds));
+                allMedianCosts[perfResultItem.Key] = median;
             }
 
             Console.WriteLine("** *** **");
+            Console.WriteLine("{0} {1} C# version: Run count = {2}, all median time costs[{3}] : {4}", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"),
+                Regex.Replace(TimeZone.CurrentTimeZone.StandardName, @"(\w)\S*\s*", "$1"),
+                PerfResults.First().Value.Count, allMedianCosts.Count, string.Join("; ", allMedianCosts.Select(kv => kv.Key + "=" + kv.Value)));
         }
 
         private static long GetMedianValue(IEnumerable<long> runTimeInSeconds)
         {
             var values = runTimeInSeconds.ToArray();
             Array.Sort(values);
-              
+
             var itemCount = values.Length;
             if (itemCount == 1)
             {
                 return values[0];
             }
 
-            if (itemCount%2 == 0)
+            if (itemCount % 2 == 0)
             {
-                return (values[itemCount/2] + values[itemCount/2 - 1])/2;
+                return (values[itemCount / 2] + values[itemCount / 2 - 1]) / 2;
             }
 
-            return values[(itemCount-1)/2];
+            return values[(itemCount - 1) / 2];
 
         }
     }

--- a/python/perf/FreebaseDeletionsBenchmark.py
+++ b/python/perf/FreebaseDeletionsBenchmark.py
@@ -1,0 +1,96 @@
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+"""
+Perf benchmark that users Freebase deletions data
+This data is licensed under CC-BY license (http:# creativecommons.org/licenses/by/2.5)
+Data is available for downloading : "Freebase Deleted Triples" at https://developers.google.com/freebase
+Data format - CSV, size - 8 GB uncompressed
+Columns in the dataset are
+    1. creation_timestamp (Unix epoch time in milliseconds)
+    2. creator
+    3. deletion_timestamp (Unix epoch time in milliseconds)
+    4. deletor
+    5. subject (MID)
+    6. predicate (MID)
+    7. object (MID/Literal)
+    8. language_code
+"""
+from __future__ import print_function
+import time
+from datetime import datetime
+from PerfBenchmark import PerfBenchmark
+
+class FreebaseDeletionsBenchmark:
+
+    @staticmethod
+    def RunRDDLineCount(args, sparkContext, sqlContext):
+        startTime = time.time()
+
+        lines = sparkContext.textFile(args[2])
+        count = lines.count()
+        elapsedDuration = time.time() - startTime
+        PerfBenchmark.ExecutionTimeList.append(elapsedDuration)
+
+        print(str(datetime.now()) + " RunRDDLineCount: Count of lines " + str(count) + ". Elapsed time = " + ("%.3f s" % elapsedDuration))
+
+
+    @staticmethod
+    def RunRDDMaxDeletionsByUser(args, sparkContext, sqlContext):
+        def map_columns(line) :
+            columns = line.split(',')
+            # data has some bad records - use bool flag to indicate corrupt rows
+            if len(columns) > 4 :
+                return (True, columns[0], columns[1], columns[2], columns[3])
+            else:
+                return (False, "X", "X", "X", "X") # invalid row placeholde
+
+        startTime = time.time()
+        lines = sparkContext.textFile(args[2])
+        parsedRows = lines.map(lambda s: map_columns(s))
+
+        flaggedRows = parsedRows.filter(lambda s: s[0]) # select good rows
+        selectedDeletions = flaggedRows.filter(lambda s: s[2] == s[4]) # select deletions made by same creators
+        userDeletions = selectedDeletions.map(lambda s: (s[2], 1))
+        userDeletionsparkContextount = userDeletions.reduceByKey(lambda x, y : x + y)
+        zeroValue = ("zerovalue", 0)
+        userWithMaxDeletions = userDeletionsparkContextount.fold(zeroValue, lambda kvp1, kvp2 : kvp1 if (kvp1[1] > kvp2[1]) else kvp2)
+
+        elapsedDuration = time.time() - startTime
+        PerfBenchmark.ExecutionTimeList.append(elapsedDuration)
+
+        print(str(datetime.now()) + " RunRDDMaxDeletionsByUser: User with max deletions is " + str(userWithMaxDeletions[0]) + ", count of deletions=" + \
+            str(userWithMaxDeletions[1]) + ". Elapsed time = " + ("%.3f s" % elapsedDuration))
+
+
+
+    @staticmethod
+    def RunDFLineCount(args, sparkContext, sqlContext):
+        startTime = time.time()
+
+        rows = sqlContext.read.format("com.databricks.spark.csv").load(args[2])
+        rowCount = rows.count()
+
+        elapsedDuration = time.time() - startTime
+        PerfBenchmark.ExecutionTimeList.append(elapsedDuration)
+
+        print(str(datetime.now()) + " RunDFLineCount: Count of rows " + str(rowCount) + ". Elapsed time = " + ("%.3f s" % elapsedDuration))
+
+
+    @staticmethod
+    def RunDFMaxDeletionsByUser(args, sparkContext, sqlContext):
+        startTime = time.time()
+        rows = sqlContext.read.format("com.databricks.spark.csv").load(args[2])
+        filtered = rows.filter("C1 = C3")
+        aggregated = filtered.groupBy("C1").agg({"C1" : "count"})
+        aggregated.registerTempTable("freebasedeletions")
+        max = sqlContext.sql("select max(`count(C1)`) from freebasedeletions")
+        maxArray = max.collect()
+        maxValue = maxArray[0]
+        maxDeletions = sqlContext.sql("select * from freebasedeletions where `count(C1)` = " + str(maxValue[0]))
+        maxDeletions.show()
+        # TODO - add perf suite for subquery
+        elapsedDuration = time.time() - startTime
+        PerfBenchmark.ExecutionTimeList.append(elapsedDuration)
+
+        print(str(datetime.now()) + " RunDFMaxDeletionsByUser: User with max deletions & count of deletions is listed above. Elapsed time = " + ("%.3f s" % elapsedDuration))

--- a/python/perf/FreebaseDeletionsBenchmark.py
+++ b/python/perf/FreebaseDeletionsBenchmark.py
@@ -81,13 +81,13 @@ class FreebaseDeletionsBenchmark:
     def RunDFMaxDeletionsByUser(args, sparkContext, sqlContext):
         startTime = time.time()
         rows = sqlContext.read.format("com.databricks.spark.csv").load(args[2])
-        filtered = rows.filter("C1 = C3")
-        aggregated = filtered.groupBy("C1").agg({"C1" : "count"})
+        filtered = rows.filter("_c1 = _c3")
+        aggregated = filtered.groupBy("_c1").agg({"_c1" : "count"})
         aggregated.registerTempTable("freebasedeletions")
-        max = sqlContext.sql("select max(`count(C1)`) from freebasedeletions")
+        max = sqlContext.sql("select max(`count(_c1)`) from freebasedeletions")
         maxArray = max.collect()
         maxValue = maxArray[0]
-        maxDeletions = sqlContext.sql("select * from freebasedeletions where `count(C1)` = " + str(maxValue[0]))
+        maxDeletions = sqlContext.sql("select * from freebasedeletions where `count(_c1)` = " + str(maxValue[0]))
         maxDeletions.show()
         # TODO - add perf suite for subquery
         elapsedDuration = time.time() - startTime

--- a/python/perf/PerfBenchmark.py
+++ b/python/perf/PerfBenchmark.py
@@ -1,0 +1,61 @@
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import time, inspect, re
+from datetime import datetime
+
+class PerfBenchmark(object):
+    PerfNameResults = {} ## <string, List<long>>
+    ExecutionTimeList = []  # List<long>
+
+    @staticmethod
+    def RunPerfSuite(perfClass, args, sparkContext, sqlContext):
+        for name, fun in inspect.getmembers(perfClass, lambda fun : inspect.isfunction(fun) and fun.__name__.startswith("Run")) :
+            PerfBenchmark.ExecutionTimeList = []
+            runCount = int(args[1])
+            for k in range(runCount):
+                print(str(datetime.now()) + " Starting perf suite : " + str(perfClass.__name__) + "." + str(name) + " times[" + str(k + 1) + "]-" + str(runCount))
+                fun(args, sparkContext, sqlContext)
+
+            executionTimeListRef = []
+            for v in PerfBenchmark.ExecutionTimeList :
+                executionTimeListRef.append(v)
+
+            PerfBenchmark.PerfNameResults[name] = executionTimeListRef
+
+
+    @staticmethod
+    def ReportResult() :
+        print(str(datetime.now()) + " ** Printing results of the perf run (python) **")
+        allMedianCosts = {}
+        for name in PerfBenchmark.PerfNameResults :
+            perfResult = PerfBenchmark.PerfNameResults[name]
+            # print(str(datetime.now()) + " " + str(result) + " time costs : " + ", ".join(("%.3f" % e) for e in perfResult))
+            # multiple enumeration happening - ignoring that for now
+            precision = "%.0f"
+            minimum = precision % min(perfResult)
+            maximum = precision % max(perfResult)
+            runCount = len(perfResult)
+            avg = precision % (sum(perfResult) / runCount)
+            median = precision % PerfBenchmark.GetMedian(perfResult)
+            values = ", ".join((precision % e) for e in perfResult)
+            print(str(datetime.now()) + " ** Execution time for " + str(name) + " in seconds: " + \
+                "Min=" + str(minimum) + ", Max=" + str(maximum) + ", Average=" + str(avg) + ", Median=" + str(median) + \
+                ".  Run count=" + str(runCount) + ", Individual execution duration=[" + values + "]")
+            allMedianCosts[name] = median
+
+        print(str(datetime.now()) + " ** *** **")
+        print(time.strftime('%Y-%m-%d %H:%M:%S ') + re.sub(r'(\w)\S*\s*', r'\1', time.strftime('%Z')) + " Python version: Run count = " + str(runCount) + ", all median time costs[" + str(len(allMedianCosts)) + "] : " + \
+            "; ".join((e + "=" + allMedianCosts[e]) for e in sorted(allMedianCosts)))
+
+    @staticmethod
+    def GetMedian(values) :
+        itemCount = len(values)
+        values.sort()
+        if itemCount == 1:
+          return values[0]
+
+        if itemCount % 2 == 0:
+          return (values[int(itemCount / 2)] + values[int(itemCount / 2 - 1)]) / 2
+
+        return values[int((itemCount - 1) / 2)]

--- a/python/perf/spark-python-perf.py
+++ b/python/perf/spark-python-perf.py
@@ -1,0 +1,33 @@
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#coding:utf8
+
+import sys, os, time
+from datetime import datetime
+from PerfBenchmark import PerfBenchmark
+from FreebaseDeletionsBenchmark import FreebaseDeletionsBenchmark
+
+if __name__ == "__main__":
+    argCount = len(sys.argv)
+    if not argCount == 3:
+        exeName = os.path.basename(__file__)
+        sys.stderr.write("Usage:     " + exeName + "  runCount   data\n")
+        sys.stderr.write("Example-1: " + exeName + "  10          hdfs:///perfdata/freebasedeletions/* \n")
+        sys.stderr.write("Example-2: " + exeName + "  1           hdfs:///perf/data/deletions/deletions.csv-00000-of-00020\n")
+        exit(-1)
+
+    print(str(datetime.now()) + " runCount = " + str(sys.argv[1]) + ", data = " + str(sys.argv[2]))
+
+    from pyspark import SparkContext,SQLContext
+    beginTime = time.time()
+
+    sparkContext = SparkContext()
+    sqlContext = SQLContext(sparkContext)
+
+    PerfBenchmark.RunPerfSuite(FreebaseDeletionsBenchmark, sys.argv, sparkContext, sqlContext)
+
+    sparkContext.stop()
+
+    PerfBenchmark.ReportResult()
+
+    print(str(datetime.now()) + " " + os.path.basename(__file__) + " : Finished python version benchmark test. Whole time = " + ("%.3f" % (time.time() - beginTime)) + " s.")

--- a/scala/perf/pom.xml
+++ b/scala/perf/pom.xml
@@ -74,7 +74,7 @@
       <dependency>
           <groupId>com.databricks</groupId>
           <artifactId>spark-csv_2.10</artifactId>
-          <version>1.3.0</version>
+          <version>1.4.0</version>
       </dependency>
   </dependencies>
 

--- a/scala/perf/src/main/com/microsoft/spark/csharp/FreebaseDeletionsBenchmark.scala
+++ b/scala/perf/src/main/com/microsoft/spark/csharp/FreebaseDeletionsBenchmark.scala
@@ -10,7 +10,7 @@ import org.apache.spark.streaming.Duration
 /**
   * Perf benchmark that users Freebase deletions data
   * This data is licensed under CC-BY license (http://creativecommons.org/licenses/by/2.5)
-  * Data is available for download at https://developers.google.com/freebase/data)
+  * Data is available for downloading : "Freebase Deleted Triples" at https://developers.google.com/freebase
   * Data format - CSV, size - 8 GB uncompressed
   * Columns in the dataset are
   *     1. creation_timestamp (Unix epoch time in milliseconds)
@@ -33,10 +33,10 @@ object FreebaseDeletionsBenchmark {
     val elapsed = System.currentTimeMillis - startTime
 
     val elapsedDuration = new Duration(elapsed)
-    val totalSeconds = elapsedDuration.milliseconds/1000
+    val totalSeconds = elapsedDuration.milliseconds / 1000
     PerfBenchmark.executionTimeList += totalSeconds
 
-    println("Count of lines " + count + ". Time elapsed " + elapsedDuration)
+    println("RunRDDLineCount: Count of lines " + count + ". Time elapsed " + elapsedDuration)
   }
 
   @PerfSuite
@@ -58,7 +58,7 @@ object FreebaseDeletionsBenchmark {
     val userDeletions = selectedDeletions.map(s => new Tuple2(s._3, 1))
     val userDeletionsCount = userDeletions.reduceByKey((x, y) => x + y)
     val zeroValue = ("zerovalue", 0)
-    val userWithMaxDeletions = userDeletionsCount.fold(zeroValue)( (kvp1, kvp2) => {
+    val userWithMaxDeletions = userDeletionsCount.fold(zeroValue)((kvp1, kvp2) => {
       if (kvp1._2 > kvp2._2)
         kvp1
       else
@@ -67,11 +67,11 @@ object FreebaseDeletionsBenchmark {
 
     val elapsed = System.currentTimeMillis - startTime
     val elapsedDuration = new Duration(elapsed)
-    val totalSeconds = elapsedDuration.milliseconds/1000
+    val totalSeconds = elapsedDuration.milliseconds / 1000
     PerfBenchmark.executionTimeList += totalSeconds
 
-    println(s"User with max deletions is " + userWithMaxDeletions._1 + ", count of deletions="
-                  + userWithMaxDeletions._2 + s". Elapsed time=$elapsedDuration")
+    println(s"RunRDDMaxDeletionsByUser: User with max deletions is " + userWithMaxDeletions._1 + ", count of deletions="
+      + userWithMaxDeletions._2 + s". Elapsed time=$elapsedDuration")
   }
 
   @PerfSuite
@@ -83,10 +83,10 @@ object FreebaseDeletionsBenchmark {
 
     val elapsed = System.currentTimeMillis - startTime
     val elapsedDuration = new Duration(elapsed)
-    val totalSeconds = elapsedDuration.milliseconds/1000
+    val totalSeconds = elapsedDuration.milliseconds / 1000
     PerfBenchmark.executionTimeList += totalSeconds
 
-    println(s"Count of rows $rowCount. Time elapsed $elapsedDuration")
+    println(s"RunDFLineCount: Count of rows $rowCount. Time elapsed $elapsedDuration")
   }
 
   @PerfSuite
@@ -105,10 +105,10 @@ object FreebaseDeletionsBenchmark {
     //TODO - add perf suite for subquery
     val elapsed = System.currentTimeMillis - startTime
     val elapsedDuration = new Duration(elapsed)
-    val totalSeconds = elapsedDuration.milliseconds/1000
+    val totalSeconds = elapsedDuration.milliseconds / 1000
     PerfBenchmark.executionTimeList += totalSeconds
 
-    println(s"User with max deletions & count of deletions is listed above. Time elapsed $elapsedDuration")
+    println(s"RunDFMaxDeletionsByUser: User with max deletions & count of deletions is listed above. Time elapsed $elapsedDuration")
   }
 
 }

--- a/scala/perf/src/main/com/microsoft/spark/csharp/FreebaseDeletionsBenchmark.scala
+++ b/scala/perf/src/main/com/microsoft/spark/csharp/FreebaseDeletionsBenchmark.scala
@@ -94,13 +94,13 @@ object FreebaseDeletionsBenchmark {
     val startTime = System.currentTimeMillis
 
     val rows = sqlContext.read.format("com.databricks.spark.csv").load(args(1))
-    val filtered = rows.filter("C1 = C3")
-    val aggregated = filtered.groupBy("C1").agg(("C1", "count"))
+    val filtered = rows.filter("_c1 = _c3")
+    val aggregated = filtered.groupBy("_c1").agg(("_c1", "count"))
     aggregated.registerTempTable("freebasedeletions")
-    val max = sqlContext.sql("select max(`count(C1)`) from freebasedeletions")
+    val max = sqlContext.sql("select max(`count(_c1)`) from freebasedeletions")
     val maxArray = max.collect
     val maxValue = maxArray(0)
-    val maxDeletions = sqlContext.sql("select * from freebasedeletions where `count(C1)` = " + maxValue.get(0))
+    val maxDeletions = sqlContext.sql("select * from freebasedeletions where `count(_c1)` = " + maxValue.get(0))
     maxDeletions.show
     //TODO - add perf suite for subquery
     val elapsed = System.currentTimeMillis - startTime

--- a/scala/perf/src/main/com/microsoft/spark/csharp/PerfBenchmark.scala
+++ b/scala/perf/src/main/com/microsoft/spark/csharp/PerfBenchmark.scala
@@ -3,8 +3,11 @@
 
 package com.microsoft.spark.csharp
 
+import java.io.File
+
 import org.apache.spark.sql.SQLContext
-import org.apache.spark.{SparkContext, SparkConf}
+import org.apache.spark.{SparkConf, SparkContext}
+
 import scala.collection.mutable.ListBuffer
 import scala.util.Sorting
 
@@ -17,6 +20,14 @@ object PerfBenchmark {
   val executionTimeList = scala.collection.mutable.ListBuffer.empty[Long]
 
   def main(args: Array[String]): Unit = {
+    if (args.length != 2) {
+      val jar = new File(PerfBenchmark.getClass.getProtectionDomain.getCodeSource.getLocation.toURI.getPath)
+      println(s"Usage   : $jar  run-times  data")
+      println(s"Example : $jar  10         hdfs:///perfdata/freebasedeletions/*")
+      println(s"Example : $jar  1          hdfs:///perf/data/deletions/deletions.csv-00000-of-00020")
+      sys.exit(1)
+    }
+
     val PerfSuite = Class.forName("com.microsoft.spark.csharp.PerfSuite")
     val sparkConf = new SparkConf().setAppName("SparkCLR perf suite - scala")
     val sparkContext = new SparkContext(sparkConf)
@@ -32,15 +43,15 @@ object PerfBenchmark {
     val freebaseDeletionsBenchmarkClass = Class.forName(className)
     val perfSuites = freebaseDeletionsBenchmarkClass.getDeclaredMethods
 
-    for ( perfSuiteMethod <- perfSuites) {
+    for (perfSuiteMethod <- perfSuites) {
       val perfSuiteName = perfSuiteMethod.getName
-      if (perfSuiteName.startsWith("Run")) { //TODO - use annotation type
+      if (perfSuiteName.startsWith("Run")) {
+        //TODO - use annotation type
         executionTimeList.clear
         var runCount = args(0).toInt
-        while (runCount > 0) {
-          println(s"Starting perf suite $perfSuiteName, runCount=$runCount")
+        for (k <- 1 to runCount) {
+          println(s"Starting perf suite $perfSuiteName : times[$k]-$runCount")
           perfSuiteMethod.invoke(freebaseDeletionsBenchmarkClass, args, sparkContext, sqlContext: SQLContext)
-          runCount = runCount - 1
         }
         val executionTimeListRef = scala.collection.mutable.ListBuffer.empty[Long]
         for (v <- executionTimeList) {
@@ -49,28 +60,26 @@ object PerfBenchmark {
         perfResults += (perfSuiteName -> executionTimeListRef)
       }
     }
-
   }
 
   def ReportResult(): Unit = {
     println("** Printing results of the perf run (scala) **")
-    for(result <- perfResults.keys) {
-        val perfResult = perfResults(result)
-        //multiple enumeration happening - ignoring that for now
-        val min = perfResult.min
-        val max = perfResult.max
-        val runCount = perfResult.length
-        val avg = perfResult.sum / runCount
-        val median = getMedian(perfResult.toList)
-        val values = new StringBuilder
-        for (value <- perfResult) {
-          values.append(value + ", ")
-        }
-
-        println(s"** Execution time for $result in seconds. Min=$min, Max=$max, Average=$avg, Median=$median, Number of runs=$runCount, Individual execution duration=[$values] **")
-      }
+    var allMedianCosts = collection.immutable.SortedMap[String, Long]()
+    for (result <- perfResults.keys) {
+      val perfResult = perfResults(result)
+      //multiple enumeration happening - ignoring that for now
+      val min = perfResult.min
+      val max = perfResult.max
+      val runCount = perfResult.length
+      val avg = perfResult.sum / runCount
+      val median = getMedian(perfResult.toList)
+      val values = perfResult.mkString(",")
+      println(s"** Execution time for $result in seconds. Min=$min, Max=$max, Average=$avg, Median=$median, Number of runs=$runCount, Individual execution duration=[$values] **")
+      allMedianCosts += (result -> median)
+    }
     println("** *** **")
-
+    val currentTime = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss zzz").format(new java.util.Date)
+    println(s"${currentTime} Scala version: Run count = ${perfResults.head._2.length}, all median time costs[${allMedianCosts.size}]: ${allMedianCosts.map(kv => kv._1 + "=" + kv._2).mkString("; ")}")
   }
 
   def getMedian(valuesList: List[Long]) = {
@@ -80,11 +89,11 @@ object PerfBenchmark {
     if (itemCount == 1)
       values(0)
 
-    if (itemCount%2 == 0) {
-      (values(itemCount/2) + values(itemCount/2 - 1))/2
+    if (itemCount % 2 == 0) {
+      (values(itemCount / 2) + values(itemCount / 2 - 1)) / 2
     }
 
-    values((itemCount-1)/2)
+    values((itemCount - 1) / 2)
   }
 }
 

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -113,7 +113,7 @@
       <dependency>
           <groupId>com.databricks</groupId>
           <artifactId>spark-csv_2.10</artifactId>
-          <version>1.3.0</version>
+          <version>1.4.0</version>
       </dependency>
   </dependencies>
 


### PR DESCRIPTION
Besides normal spark-submit , there's a convenient way using https://github.com/qualiu/testMobius
**1.Cluster mode examples as following:**
```
D:\msgit\lqmMobius\testMobius\scripts\perf\submit-python-perf-test.bat d:\msgit\lqmMobius\python\perf 10 hdfs:///perf/data/deletions/*
D:\msgit\lqmMobius\testMobius\scripts\perf\submit-scala-perf-test.bat  d:\msgit\lqmMobius\scala\perf  10
D:\msgit\lqmMobius\testMobius\scripts\perf\submit-mobius-perf-test.bat d:\msgit\lqmMobius\csharp\perf 10

```

**2.Local mode examples :**
(1) First set SparkOptions : just copy the "Local Mode set SparkOptions=" after running the bat without arguments.
(2) Then submit local test : (you should have downloaded or copied the test data, like d:\mobius\deletions)
```
D:\msgit\lqmMobius\testMobius\scripts\perf\submit-python-perf-test.bat d:\msgit\lqmMobius\python\perf 3 d:\mobius\deletions\deletions.csv-00000-of-00020
D:\msgit\lqmMobius\testMobius\scripts\perf\submit-scala-perf-test.bat  d:\msgit\lqmMobius\scala\perf  3 d:\mobius\deletions\deletions.csv-00000-of-00020
D:\msgit\lqmMobius\testMobius\scripts\perf\submit-mobius-perf-test.bat d:\msgit\lqmMobius\csharp\perf 3 d:\mobius\deletions\deletions.csv-00000-of-00020

```