### PR TITLE
Use copy task instead of OS commands so it builds on OSX

### DIFF
--- a/csharp/Perf/Microsoft.Spark.CSharp/PerfBenchmark.csproj
+++ b/csharp/Perf/Microsoft.Spark.CSharp/PerfBenchmark.csproj
@@ -71,11 +71,10 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-      <Target Name="AfterBuild">
-        <Copy SkipUnchangedFiles="true" SourceFiles="$(ProjectDir)..\..\..\csharp\Worker\Microsoft.Spark.CSharp\bin\$(ConfigurationName)\CSharpWorker.*" DestinationFiles="$(TargetDir)" />
-      </Target>
-  </PropertyGroup>
+  <Target Name="CopyCSharpWorker"
+      DependsOn="CoreBuild">
+    <Copy SkipUnchangedFiles="true" SourceFiles="$(ProjectDir)..\..\..\csharp\Worker\Microsoft.Spark.CSharp\bin\$(ConfigurationName)\CSharpWorker.*" DestinationFiles="$(TargetDir)" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/csharp/Perf/Microsoft.Spark.CSharp/PerfBenchmark.csproj
+++ b/csharp/Perf/Microsoft.Spark.CSharp/PerfBenchmark.csproj
@@ -72,8 +72,9 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">copy /y $(ProjectDir)..\..\..\csharp\Worker\Microsoft.Spark.CSharp\bin\$(ConfigurationName)\CSharpWorker.* $(TargetDir)</PostBuildEvent>
-    <PostBuildEvent Condition=" '$(OS)' == 'Unix' ">cp -uv $(ProjectDir)../../../csharp/Worker/Microsoft.Spark.CSharp/bin/$(ConfigurationName)/CSharpWorker.* $(TargetDir)</PostBuildEvent>
+      <Target Name="AfterBuild">
+        <Copy SkipUnchangedFiles="true" SourceFiles="$(ProjectDir)..\..\..\csharp\Worker\Microsoft.Spark.CSharp\bin\$(ConfigurationName)\CSharpWorker.*" DestinationFiles="$(TargetDir)" />
+      </Target>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/csharp/Perf/Microsoft.Spark.CSharp/PerfBenchmark.csproj
+++ b/csharp/Perf/Microsoft.Spark.CSharp/PerfBenchmark.csproj
@@ -72,7 +72,7 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="CopyCSharpWorker"
-      DependsOn="CoreBuild">
+      DependsOnTargets="CoreBuild">
     <Copy SkipUnchangedFiles="true" SourceFiles="$(ProjectDir)..\..\..\csharp\Worker\Microsoft.Spark.CSharp\bin\$(ConfigurationName)\CSharpWorker.*" DestinationFiles="$(TargetDir)" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
cp -uv is run on OSX, but the option -u is not available in OSX, so I'm using the copy task which works cross operating system. It lets msbuild take care of operation system copying functionality. 