### PR TITLE
use forward slash to work in linux/osx

### DIFF
--- a/scripts/sparkclr-submit.sh
+++ b/scripts/sparkclr-submit.sh
@@ -10,13 +10,13 @@ function spark_home_error() {
 	echo "[sparkclr-submit.sh] Note that SPARK_HOME environment variable should not have trailing /"
 	exit 1
 }
-	
+
 function java_home_error() {
 	echo "[sparkclr-submit.sh] Error - JAVA_HOME environment variable is not set"
 	echo "[sparkclr-submit.sh] Note that JAVA_HOME environment variable should not have trailing /"
 	exit 1
 }
-	
+
 function sparkclr_home_error() {
 	echo "[sparkclr-submit.sh] Error - SPARKCLR_HOME environment variable is not set"
 	echo "[sparkclr-submit.sh] SPARKCLR_HOME need to be set to the folder path for csharp-spark*.jar"
@@ -55,7 +55,7 @@ then
   exit 1
 fi
 
-export SPARK_JARS_CLASSPATH="$SPARK_JARS_DIR\*"
+export SPARK_JARS_CLASSPATH="$SPARK_JARS_DIR/*"
 
 export SPARKCLR_JAR=spark-clr_2.11-2.0.000-SNAPSHOT.jar
 export SPARKCLR_CLASSPATH="$SPARKCLR_HOME/lib/$SPARKCLR_JAR"
@@ -71,7 +71,7 @@ else
 
   # The launcher library prints the arguments to be submitted to spark-submit.sh. So read all the output of the launcher into a variable.
   export SPARK_ARGS=`"$JAVA_HOME/bin/java" -cp "$LAUNCH_CLASSPATH" org.apache.spark.launcher.SparkCLRSubmitArguments "$@"`
-  
+
   # launches the Spark job with spark-submit.sh
   echo "[sparkclr-submit.sh] Command to run $SPARK_ARGS"
   "$SPARK_HOME/bin/spark-submit" $SPARK_ARGS


### PR DESCRIPTION
Sparks Jar ClassPath doesn't work in in linux because of back slash.  This fixes that. 