### PR TITLE
fixing the issue in YARN clusters introduced during Spark 2.0 upgrade

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Configuration/ConfigurationService.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Configuration/ConfigurationService.cs
@@ -65,7 +65,9 @@ namespace Microsoft.Spark.CSharp.Configuration
                 configuration = new SparkCLRConfiguration(appConfig);
                 runMode = RunMode.CLUSTER;
             }
-            else if (sparkMaster.Equals("yarn-client", StringComparison.OrdinalIgnoreCase) || sparkMaster.Equals("yarn-cluster", StringComparison.OrdinalIgnoreCase))
+            else if (sparkMaster.Equals("yarn-cluster", StringComparison.OrdinalIgnoreCase) ||
+                     sparkMaster.Equals("yarn-client", StringComparison.OrdinalIgnoreCase) ||
+                     sparkMaster.Equals("yarn", StringComparison.OrdinalIgnoreCase)) //supported in Spark 2.0
             {
                 configuration = new SparkCLRConfiguration(appConfig);
                 runMode = RunMode.YARN;

--- a/scala/src/main/org/apache/spark/api/csharp/CSharpRDD.scala
+++ b/scala/src/main/org/apache/spark/api/csharp/CSharpRDD.scala
@@ -68,7 +68,7 @@ class CSharpRDD(
     val func = SQLUtils.createCSharpFunction(command,
                                                     envVars,
                                                     cSharpIncludes,
-                                                    cSharpWorkerExecutable,
+                                                    cSharpWorker.getAbsolutePath,
                                                     unUsedVersionIdentifier,
                                                     broadcastVars,
                                                     accumulator)


### PR DESCRIPTION
Adding "yarn" as a valid value for master config - this is allowed in Spark 2.0
Fixing the issues in launching CSharpWorker.exe in YARN clusters - introduced during Spark 2.0 upgrade
