### PR TITLE
Fix Spark version build problems

### DIFF
--- a/build/localmode/RunSamples.cmd
+++ b/build/localmode/RunSamples.cmd
@@ -47,7 +47,7 @@ if "%precheck%" == "bad" (goto :EOF)
 @rem 
 @rem setup Hadoop and Spark versions
 @rem
-set SPARK_VERSION=2.0.0
+set SPARK_VERSION=2.0.1
 set HADOOP_VERSION=2.6
 @echo [RunSamples.cmd] SPARK_VERSION=%SPARK_VERSION%, HADOOP_VERSION=%HADOOP_VERSION%
 

--- a/build/localmode/RunSamples.cmd
+++ b/build/localmode/RunSamples.cmd
@@ -47,7 +47,7 @@ if "%precheck%" == "bad" (goto :EOF)
 @rem 
 @rem setup Hadoop and Spark versions
 @rem
-set SPARK_VERSION=2.0.1
+set SPARK_VERSION=2.0.0
 set HADOOP_VERSION=2.6
 @echo [RunSamples.cmd] SPARK_VERSION=%SPARK_VERSION%, HADOOP_VERSION=%HADOOP_VERSION%
 

--- a/build/localmode/RunSamples.cmd
+++ b/build/localmode/RunSamples.cmd
@@ -49,7 +49,8 @@ if "%precheck%" == "bad" (goto :EOF)
 @rem
 set SPARK_VERSION=2.0.0
 set HADOOP_VERSION=2.6
-@echo [RunSamples.cmd] SPARK_VERSION=%SPARK_VERSION%, HADOOP_VERSION=%HADOOP_VERSION%
+set APACHE_DIST_SERVER=archive.apache.org
+@echo [RunSamples.cmd] SPARK_VERSION=%SPARK_VERSION%, HADOOP_VERSION=%HADOOP_VERSION%, APACHE_DIST_SERVER=%APACHE_DIST_SERVER%
 
 @rem download runtime dependencies
 pushd "%CMDHOME%"

--- a/build/localmode/downloadtools.ps1
+++ b/build/localmode/downloadtools.ps1
@@ -73,8 +73,16 @@ function Download-File($url, $output)
     $output = [System.IO.Path]::GetFullPath($output)
     if (test-path $output)
     {
-        Write-Output "[downloadtools.Download-File] $output exists. No need to download."
-        return
+        if ((Get-Item $output).Length -gt 0)
+        {
+            Write-Output "[downloadtools.Download-File] $output exists. No need to download."
+            return
+        }
+        else
+        {
+            Write-Output "[downloadtools.Download-File] [WARNING] $output exists but is empty. We need to download a new copy of the file."
+            Remove-Item $output
+        }
     }
 
     $start_time = Get-Date
@@ -122,6 +130,11 @@ function Download-File($url, $output)
     }
 
     Write-Output "[downloadtools.Download-File] Download completed. Time taken: $howlong"
+    
+    if ( !(test-path $output) -or (Get-Item $output).Length -eq 0)
+    {
+        throw [System.IO.FileNotFoundException] "Failed to download file $output from $url"
+    }
 }
 
 function Unzip-File($zipFile, $targetDir)

--- a/build/localmode/downloadtools.ps1
+++ b/build/localmode/downloadtools.ps1
@@ -17,7 +17,7 @@ if ($stage.ToLower() -eq "run")
     $hadoopVersion = if ($envValue -eq $null) { "2.6" } else { $envValue }
     
     $envValue = [Environment]::GetEnvironmentVariable("SPARK_VERSION")
-    $sparkVersion = if ($envValue -eq $null) { "1.6.1" } else { $envValue }
+    $sparkVersion = if ($envValue -eq $null) { "1.6.2" } else { $envValue }
     
     Write-Output "[downloadtools] hadoopVersion=$hadoopVersion, sparkVersion=$sparkVersion"
 }

--- a/build/localmode/downloadtools.ps1
+++ b/build/localmode/downloadtools.ps1
@@ -18,8 +18,11 @@ if ($stage.ToLower() -eq "run")
     
     $envValue = [Environment]::GetEnvironmentVariable("SPARK_VERSION")
     $sparkVersion = if ($envValue -eq $null) { "1.6.1" } else { $envValue }
+
+    $envValue = [Environment]::GetEnvironmentVariable("APACHE_DIST_SERVER")
+    $apacheDistServer = if ($envValue -eq $null) { "archive.apache.org" } else { $envValue }
     
-    Write-Output "[downloadtools] hadoopVersion=$hadoopVersion, sparkVersion=$sparkVersion"
+    Write-Output "[downloadtools] hadoopVersion=$hadoopVersion, sparkVersion=$sparkVersion, apacheDistServer=$apacheDistServer"
 }
 
 function Get-ScriptDirectory
@@ -265,7 +268,7 @@ function Download-BuildTools
     $mvnCmd = "$toolsDir\$mvnVer\bin\mvn.cmd"
     if (!(test-path $mvnCmd))
     {
-        $url = "http://www.us.apache.org/dist/maven/maven-3/3.3.9/binaries/$mvnVer-bin.tar.gz"
+        $url = "http://$apacheDistServer/dist/maven/maven-3/3.3.9/binaries/$mvnVer-bin.tar.gz"
         $output="$toolsDir\$mvnVer-bin.tar.gz"
         Download-File $url $output
         Untar-File $output $toolsDir
@@ -415,7 +418,7 @@ function Download-RuntimeDependencies
     $sparkSubmit="$S_HOME\bin\spark-submit.cmd"
     if (!(test-path $sparkSubmit))
     {
-        $url = "http://www.us.apache.org/dist/spark/spark-$sparkVersion/spark-$sparkVersion-bin-hadoop$hadoopVersion.tgz"
+        $url = "http://$apacheDistServer/dist/spark/spark-$sparkVersion/spark-$sparkVersion-bin-hadoop$hadoopVersion.tgz"
         $output = "$toolsDir\spark-$sparkVersion-bin-hadoop$hadoopVersion.tgz"
         Download-File $url $output
         Untar-File $output $toolsDir

--- a/build/localmode/downloadtools.ps1
+++ b/build/localmode/downloadtools.ps1
@@ -17,7 +17,7 @@ if ($stage.ToLower() -eq "run")
     $hadoopVersion = if ($envValue -eq $null) { "2.6" } else { $envValue }
     
     $envValue = [Environment]::GetEnvironmentVariable("SPARK_VERSION")
-    $sparkVersion = if ($envValue -eq $null) { "1.6.2" } else { $envValue }
+    $sparkVersion = if ($envValue -eq $null) { "1.6.1" } else { $envValue }
     
     Write-Output "[downloadtools] hadoopVersion=$hadoopVersion, sparkVersion=$sparkVersion"
 }

--- a/build/localmode/downloadtools.ps1
+++ b/build/localmode/downloadtools.ps1
@@ -10,6 +10,9 @@
 #
 Param([string] $stage, [string] $verbose)
 
+$envValue = [Environment]::GetEnvironmentVariable("APACHE_DIST_SERVER")
+$apacheDistServer = if ($envValue -eq $null) { "archive.apache.org" } else { $envValue }
+    
 if ($stage.ToLower() -eq "run")
 {
     # retrieve hadoop and spark versions from environment variables
@@ -19,9 +22,6 @@ if ($stage.ToLower() -eq "run")
     $envValue = [Environment]::GetEnvironmentVariable("SPARK_VERSION")
     $sparkVersion = if ($envValue -eq $null) { "1.6.1" } else { $envValue }
 
-    $envValue = [Environment]::GetEnvironmentVariable("APACHE_DIST_SERVER")
-    $apacheDistServer = if ($envValue -eq $null) { "archive.apache.org" } else { $envValue }
-    
     Write-Output "[downloadtools] hadoopVersion=$hadoopVersion, sparkVersion=$sparkVersion, apacheDistServer=$apacheDistServer"
 }
 

--- a/build/localmode/run-samples.sh
+++ b/build/localmode/run-samples.sh
@@ -16,7 +16,7 @@ do
 done
 
 # setup Hadoop and Spark versions
-export SPARK_VERSION=2.0.1
+export SPARK_VERSION=2.0.0
 export HADOOP_VERSION=2.6
 echo "[run-samples.sh] SPARK_VERSION=$SPARK_VERSION, HADOOP_VERSION=$HADOOP_VERSION"
 

--- a/build/localmode/run-samples.sh
+++ b/build/localmode/run-samples.sh
@@ -18,7 +18,8 @@ done
 # setup Hadoop and Spark versions
 export SPARK_VERSION=2.0.0
 export HADOOP_VERSION=2.6
-echo "[run-samples.sh] SPARK_VERSION=$SPARK_VERSION, HADOOP_VERSION=$HADOOP_VERSION"
+export APACHE_DIST_SERVER=archive.apache.org
+echo "[run-samples.sh] SPARK_VERSION=$SPARK_VERSION, HADOOP_VERSION=$HADOOP_VERSION, APACHE_DIST_SERVER=$APACHE_DIST_SERVER"
 
 export FWDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -30,7 +31,7 @@ export SPARK=spark-$SPARK_VERSION-bin-hadoop$HADOOP_VERSION
 export SPARK_HOME="$TOOLS_DIR/$SPARK"
 if [ ! -d "$SPARK_HOME" ];
 then
-  wget "http://www.us.apache.org/dist/spark/spark-$SPARK_VERSION/$SPARK.tgz" -O "$TOOLS_DIR/$SPARK.tgz"
+  wget "http://$APACHE_DIST_SERVER/dist/spark/spark-$SPARK_VERSION/$SPARK.tgz" -O "$TOOLS_DIR/$SPARK.tgz"
   tar xfz "$TOOLS_DIR/$SPARK.tgz" -C "$TOOLS_DIR"
 fi
 export PATH="$SPARK_HOME/bin:$PATH"

--- a/build/localmode/run-samples.sh
+++ b/build/localmode/run-samples.sh
@@ -16,7 +16,7 @@ do
 done
 
 # setup Hadoop and Spark versions
-export SPARK_VERSION=2.0.0
+export SPARK_VERSION=2.0.1
 export HADOOP_VERSION=2.6
 echo "[run-samples.sh] SPARK_VERSION=$SPARK_VERSION, HADOOP_VERSION=$HADOOP_VERSION"
 


### PR DESCRIPTION
(1) Fix outdated version of Spark binary distributions from Apache being used in Mobius builds.
- Specifically, Spark `2.0.0` is no longer available as a binary `.tgz` distribution from Apache Software Foundation Distribution server.
  http://www.us.apache.org/dist/spark/
- Only versions `1.6.2` and `2.0.1` of Spark binary distributions are available for download from the Apache Distribution server now.

```
http://www.us.apache.org/dist/spark/

[DIR] spark-1.6.2/            2016-06-25 07:38    -
[DIR] spark-2.0.1/            2016-10-04 17:26    -
```
- This Pull Request changes the Spark version defaults in Mobius download scripts to match what is the currently available from Apache:
  
  `1.6.1` -> `1.6.2` and `2.0.0` -> `2.0.1`

(2) Add guard code to check that Download-File function got a real file.
- Check in the `Download-File` function that the current downloaded copy of the file is not empty [zero length].

**Failure Mode**
[From my VSO hosted build server environment - which does no caching of previous downloaded files]

```
2016-10-27T16:30:29.7363825Z [downloadtools.Download-File] Start downloading http://www.us.apache.org/dist/spark/spark-2.0.0/spark-2.0.0-bin-hadoop2.6.tgz to C:\a\1\s\build\tools\spark-2.0.0-bin-hadoop2.6.tgz ...
2016-10-27T16:30:29.7763815Z 
2016-10-27T16:30:29.7813808Z Id     Name            PSJobTypeName   State         HasMoreData     Location  
2016-10-27T16:30:29.7813808Z --     ----            -------------   -----         -----------     --------  
2016-10-27T16:30:29.7883809Z 1      Web.Download...                 NotStarted    False                     
2016-10-27T16:30:29.7913858Z 2      Web.Download...                 NotStarted    False                     
2016-10-27T16:30:29.9483826Z [downloadtools.Download-File] Download completed. Time taken: 202 milliseconds
2016-10-27T16:30:29.9513819Z [downloadtools.Untar-File] Extracting C:\a\1\s\build\localmode\..\tools\spark-2.0.0-bin-hadoop2.6.tgz to C:\a\1\s\build\localmode\..\tools ...
2016-10-27T16:30:30.0603812Z Error extracting C:\a\1\s\build\localmode\..\tools\spark-2.0.0-bin-hadoop2.6.tgz 
2016-10-27T16:30:30.0603812Z Exception message EOS reading GZIP header
2016-10-27T16:30:30.0623815Z Usage : >TarTool sourceFile destinationDirectory
2016-10-27T16:30:30.0623815Z >TarTool D:\sample.tar.gz ./
2016-10-27T16:30:30.0623815Z >TarTool sample.tgz temp
2016-10-27T16:30:30.0623815Z >TarTool -x sample.tar temp
2016-10-27T16:30:30.6098995Z [downloadtools.Untar-File] Extraction completed. Time taken: 658 milliseconds
```
