### PR TITLE
Fix ReduceByKey failure when the value type is a reference type

### DIFF
--- a/csharp/AdapterTest/PairRDDTest.cs
+++ b/csharp/AdapterTest/PairRDDTest.cs
@@ -105,6 +105,7 @@ namespace AdapterTest
             }
         }
 
+        [Serializable]
         private class IntWrapper
         {
             public IntWrapper(int value)
@@ -120,9 +121,21 @@ namespace AdapterTest
         {
             // The ReduceByKey method below fails with NPE if ReduceByKey
             // calls CombineByKey with () => default(V) as seed generator
-            pairs
+            var sums = pairs
                 .MapValues(value => new IntWrapper(value))
                 .ReduceByKey((x, y) => new IntWrapper(x.Value + y.Value));
+
+            var result = sums
+                .CollectAsMap()
+                .Select(pair => new KeyValuePair<string, int>(pair.Key, pair.Value.Value))
+                .ToList();
+
+            var expectedResult = pairs
+                .ReduceByKey((x, y) => x + y)
+                .CollectAsMap()
+                .ToList();
+
+            Assert.That(result, Is.EquivalentTo(expectedResult));
         }
 
         [Test]

--- a/csharp/AdapterTest/PairRDDTest.cs
+++ b/csharp/AdapterTest/PairRDDTest.cs
@@ -105,6 +105,26 @@ namespace AdapterTest
             }
         }
 
+        private class IntWrapper
+        {
+            public IntWrapper(int value)
+            {
+                Value = value;
+            }
+
+            public int Value { get; }
+        }
+
+        [Test]
+        public void TestPairRddReduceByKeyWithObjects()
+        {
+            // The ReduceByKey method below fails with NPE if ReduceByKey
+            // calls CombineByKey with () => default(V) as seed generator
+            pairs
+                .MapValues(value => new IntWrapper(value))
+                .ReduceByKey((x, y) => new IntWrapper(x.Value + y.Value));
+        }
+
         [Test]
         public void TestPairRddFoldByKey()
         {


### PR DESCRIPTION
ReduceByKey fails with a NPE if the value type is a reference type, even if there are no null values in the PairRDD. 

The reason of the error is that ReduceByKey calls CombineByKey with a seed generator of () => default(V). When the value is a reference type, this seed value is null. The lambda will try to accumulate the values to this seed value of null. A unit test was added to demonstrate this behavior.

The fix not only avoids NPE errors, but it is also more efficient, because it calls the lambda of the ReduceByKey for actual value pairs only.

This behavior is also in line with the Scala and Java execution: ReduceByKey doesn't call the lambda with the default value of the data type.