### PR TITLE
DStream ReduceByKey will fail with reference types

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Streaming/PairDStreamFunctions.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Streaming/PairDStreamFunctions.cs
@@ -35,7 +35,6 @@ namespace Microsoft.Spark.CSharp.Streaming
             var shuffled = locallyCombined.PartitionBy(numPartitions);
 
             return shuffled.MapPartitionsWithIndex(new GroupByMergeHelper<K, V>(reduceFunc).Execute, true);
-            //return self.CombineByKey(() => default(V) == null ? (V) Activator.CreateInstance(typeof(V)) : default(V), reduceFunc, reduceFunc, numPartitions);
         }
 
         /// <summary>

--- a/csharp/Adapter/documentation/Microsoft.Spark.CSharp.Adapter.Doc.XML
+++ b/csharp/Adapter/documentation/Microsoft.Spark.CSharp.Adapter.Doc.XML
@@ -8488,7 +8488,7 @@
             the given function on the previous state of the key and the new values of the key.
             </summary>
         </member>
-        <member name="T:Microsoft.Spark.CSharp.Streaming.CombineByKeyHelper`3">
+        <member name="T:Microsoft.Spark.CSharp.Streaming.GroupByMergeHelper`2">
             <summary>
             Following classes are defined explicitly instead of using anonymous method as delegate to prevent C# compiler from generating
             private anonymous type that is not marked serializable. Since the delegate has to be serialized and sent to the Spark workers


### PR DESCRIPTION
This fix depends on #605, and is related to #602