### PR TITLE
Expose JobExecutionStatus in SparkJobInfo as an enum

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Core/StatusTracker.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Core/StatusTracker.cs
@@ -80,13 +80,36 @@ namespace Microsoft.Spark.CSharp.Core
     }
 
     /// <summary>
+    /// Status associated with a job information of Spark
+    /// </summary>
+    public enum JobExecutionStatus
+    {
+        /// <summary>
+        /// Spark Job execution has failed
+        /// </summary>
+        Failed,
+        /// <summary>
+        /// Spark Job execution is currently running
+        /// </summary>
+        Running,
+        /// <summary>
+        /// Spark Job execution has succeeded
+        /// </summary>
+        Succeeded,
+        /// <summary>
+        /// Spark Job status is unknown
+        /// </summary>
+        Unknown,
+    }
+
+    /// <summary>
     /// SparkJobInfo represents a job information of Spark
     /// </summary>
     public class SparkJobInfo
     {
         readonly int jobId;
         readonly int[] stageIds;
-        readonly string status;
+        readonly JobExecutionStatus status;
 
         /// <summary>
         /// Initializes a SparkJobInfo instance with a given job Id, stage Ids, and status
@@ -94,7 +117,7 @@ namespace Microsoft.Spark.CSharp.Core
         /// <param name="jobId"></param>
         /// <param name="stageIds"></param>
         /// <param name="status"></param>
-        public SparkJobInfo(int jobId, int[] stageIds, string status)
+        public SparkJobInfo(int jobId, int[] stageIds, JobExecutionStatus status)
         {
             this.jobId = jobId;
             this.stageIds = stageIds;
@@ -114,7 +137,7 @@ namespace Microsoft.Spark.CSharp.Core
         /// <summary>
         /// Gets the status of this Spark job
         /// </summary>
-        public string Status { get { return status; } }
+        public JobExecutionStatus Status { get { return status; } }
 
     }
 
@@ -191,7 +214,7 @@ namespace Microsoft.Spark.CSharp.Core
         public int NumCompletedTasks { get { return numCompletedTasks; } }
 
         /// <summary>
-        /// Gets the number of failed tasks of this SparkStageInfro
+        /// Gets the number of failed tasks of this SparkStageInfo
         /// </summary>
         public int NumFailedTasks { get { return numFailedTasks; } }
     }

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/StatusTrackerIpcProxy.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/StatusTrackerIpcProxy.cs
@@ -44,7 +44,8 @@ namespace Microsoft.Spark.CSharp.Proxy.Ipc
 
             JvmObjectReference jJobInfo = new JvmObjectReference((string)jobInfoId);
             int[] stageIds = (int[])SparkCLRIpcProxy.JvmBridge.CallNonStaticJavaMethod(jJobInfo, "stageIds");
-            string status = SparkCLRIpcProxy.JvmBridge.CallNonStaticJavaMethod(jJobInfo, "status").ToString();
+            string statusString = SparkCLRIpcProxy.JvmBridge.CallNonStaticJavaMethod(jJobInfo, "status").ToString();
+            var status = (JobExecutionStatus) Enum.Parse(typeof(JobExecutionStatus), statusString, true);
 
             return new SparkJobInfo(jobId, stageIds, status);
         }

--- a/csharp/Adapter/documentation/Microsoft.Spark.CSharp.Adapter.Doc.XML
+++ b/csharp/Adapter/documentation/Microsoft.Spark.CSharp.Adapter.Doc.XML
@@ -2559,12 +2559,37 @@
             <param name="stageId"></param>
             <returns></returns>
         </member>
+        <member name="T:Microsoft.Spark.CSharp.Core.JobExecutionStatus">
+            <summary>
+            Status associated with a job information of Spark
+            </summary>
+        </member>
+        <member name="F:Microsoft.Spark.CSharp.Core.JobExecutionStatus.Failed">
+            <summary>
+            Spark Job execution has failed
+            </summary>
+        </member>
+        <member name="F:Microsoft.Spark.CSharp.Core.JobExecutionStatus.Running">
+            <summary>
+            Spark Job execution is currently running
+            </summary>
+        </member>
+        <member name="F:Microsoft.Spark.CSharp.Core.JobExecutionStatus.Succeeded">
+            <summary>
+            Spark Job execution has succeeded
+            </summary>
+        </member>
+        <member name="F:Microsoft.Spark.CSharp.Core.JobExecutionStatus.Unknown">
+            <summary>
+            Spark Job status is unknown
+            </summary>
+        </member>
         <member name="T:Microsoft.Spark.CSharp.Core.SparkJobInfo">
             <summary>
             SparkJobInfo represents a job information of Spark
             </summary>
         </member>
-        <member name="M:Microsoft.Spark.CSharp.Core.SparkJobInfo.#ctor(System.Int32,System.Int32[],System.String)">
+        <member name="M:Microsoft.Spark.CSharp.Core.SparkJobInfo.#ctor(System.Int32,System.Int32[],Microsoft.Spark.CSharp.Core.JobExecutionStatus)">
             <summary>
             Initializes a SparkJobInfo instance with a given job Id, stage Ids, and status
             </summary>
@@ -2642,7 +2667,7 @@
         </member>
         <member name="P:Microsoft.Spark.CSharp.Core.SparkStageInfo.NumFailedTasks">
             <summary>
-            Gets the number of failed tasks of this SparkStageInfro
+            Gets the number of failed tasks of this SparkStageInfo
             </summary>
         </member>
         <member name="T:Microsoft.Spark.CSharp.Core.StorageLevelType">

--- a/csharp/Adapter/documentation/Mobius_API_Documentation.md
+++ b/csharp/Adapter/documentation/Mobius_API_Documentation.md
@@ -362,6 +362,13 @@
 ---
   
   
+###<font color="#68228B">Microsoft.Spark.CSharp.Core.JobExecutionStatus</font>
+####Summary
+  
+            
+            Status associated with a job information of Spark
+            
+        
 ###<font color="#68228B">Microsoft.Spark.CSharp.Core.SparkJobInfo</font>
 ####Summary
   

--- a/csharp/AdapterTest/StatusTrackerTest.cs
+++ b/csharp/AdapterTest/StatusTrackerTest.cs
@@ -68,11 +68,12 @@ namespace AdapterTest
         /// Test StatusTracker.GetJobInfo() and methods of class SparkJobInfo.
         /// </summary>
         [Test]
-        public void TestSparkJobInfo()
+        public void TestSparkJobInfo(
+            [Values(JobExecutionStatus.Failed, JobExecutionStatus.Running, JobExecutionStatus.Succeeded, JobExecutionStatus.Unknown)] JobExecutionStatus status
+            )
         {
             const int jobId = 65536;
             int[] stageIds = new[] { 100, 102, 104 };
-            const string status = "RUNNING";
 
             // arrange
             Mock<IStatusTrackerProxy> statusTrackerProxy = new Mock<IStatusTrackerProxy>();


### PR DESCRIPTION
Change the interface of SparkJobInfo to be more inline with the scala implementation.