### PR TITLE
Update TarTool direct link.

### DIFF
--- a/build/localmode/downloadtools.ps1
+++ b/build/localmode/downloadtools.ps1
@@ -247,7 +247,7 @@ function Download-BuildTools
     $tarToolExe = "$toolsDir\TarTool.exe"
     if (!(test-path $tarToolExe))
     {
-        $url = "http://download-codeplex.sec.s-msft.com/Download/Release?ProjectName=tartool&DownloadId=79064&FileTime=128946542158770000&Build=21031"
+        $url = "http://download-codeplex.sec.s-msft.com/Download/Release?ProjectName=tartool&DownloadId=79064&FileTime=128946542158770000&Build=21046"
         $output="$toolsDir\TarTool.zip"
         Download-File $url $output
         Unzip-File $output $toolsDir


### PR DESCRIPTION
A more permanent solution here needs to be found so that
we do not need to update this link. In the meantime, this
will unblock users from successfully building