### PR TITLE
Update projects to treat warnings as errors.

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Adapter.csproj
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Adapter.csproj
@@ -25,6 +25,7 @@
     <Prefer32Bit>false</Prefer32Bit>
     <DocumentationFile>..\documentation\Microsoft.Spark.CSharp.Adapter.Doc.XML</DocumentationFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Sql/HiveContext.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Sql/HiveContext.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Spark.CSharp.Sql
         /// <returns></returns>
         public new DataFrame Sql(string sqlQuery)
         {
-            return new DataFrame(SqlContextProxy.Sql(sqlQuery), sparkContext);
+            return new DataFrame(SqlContextProxy.Sql(sqlQuery), SparkContext);
         }
 
         /// <summary>

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Sql/SparkSession.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Sql/SparkSession.cs
@@ -48,6 +48,9 @@ namespace Microsoft.Spark.CSharp.Sql
             get { return sparkContext; }
         }
 
+        /// <summary>
+        /// Interface through which the user may register User Defined Functions.
+        /// </summary>
         public UdfRegistration Udf
         {
             get { return new UdfRegistration(sparkSessionProxy.Udf); }

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Sql/SqlContext.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Sql/SqlContext.cs
@@ -18,12 +18,12 @@ namespace Microsoft.Spark.CSharp.Sql
         private readonly ILoggerService logger = LoggerServiceFactory.GetLogger(typeof(SqlContext));
 
         private readonly ISqlContextProxy sqlContextProxy;
-        protected readonly SparkContext sparkContext;
         internal ISqlContextProxy SqlContextProxy { get { return sqlContextProxy; } }
 
         private static SqlContext instance;
 
-        private SparkSession sparkSession;
+        private readonly SparkSession sparkSession;
+        private readonly SparkContext sparkContext;
         private bool isRootContext;
 
         /// <summary>
@@ -32,6 +32,14 @@ namespace Microsoft.Spark.CSharp.Sql
         public SparkSession SparkSession
         {
             get { return sparkSession; }
+        }
+
+        /// <summary>
+        /// Underlying SparkContext
+        /// </summary>
+        public SparkContext SparkContext
+        {
+            get { return sparkContext; }
         }
 
         internal SqlContext(SparkSession sparkSession, bool isRootContext)

--- a/csharp/Adapter/documentation/Microsoft.Spark.CSharp.Adapter.Doc.XML
+++ b/csharp/Adapter/documentation/Microsoft.Spark.CSharp.Adapter.Doc.XML
@@ -7040,14 +7040,14 @@
             databases, tables, functions etc.
             </summary>
         </member>
-        <member name="P:Microsoft.Spark.CSharp.Sql.SparkSession.Udf">
-            <summary>
-            Interface through which the user may register User Defined Functions.
-            </summary>
-        </member>
         <member name="P:Microsoft.Spark.CSharp.Sql.SparkSession.SparkContext">
             <summary>
             Interface through which the user may access the underlying SparkContext.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Sql.SparkSession.Udf">
+            <summary>
+            Interface through which the user may register User Defined Functions.
             </summary>
         </member>
         <member name="M:Microsoft.Spark.CSharp.Sql.SparkSession.Builder">

--- a/csharp/Adapter/documentation/Microsoft.Spark.CSharp.Adapter.Doc.XML
+++ b/csharp/Adapter/documentation/Microsoft.Spark.CSharp.Adapter.Doc.XML
@@ -7040,6 +7040,11 @@
             databases, tables, functions etc.
             </summary>
         </member>
+        <member name="P:Microsoft.Spark.CSharp.Sql.SparkSession.Udf">
+            <summary>
+            Interface through which the user may register User Defined Functions.
+            </summary>
+        </member>
         <member name="M:Microsoft.Spark.CSharp.Sql.SparkSession.Builder">
             <summary>
             Builder for SparkSession
@@ -7097,6 +7102,11 @@
         <member name="P:Microsoft.Spark.CSharp.Sql.SqlContext.SparkSession">
             <summary>
             Underlying SparkSession
+            </summary>
+        </member>
+        <member name="P:Microsoft.Spark.CSharp.Sql.SqlContext.SparkContext">
+            <summary>
+            Underlying SparkContext
             </summary>
         </member>
         <member name="M:Microsoft.Spark.CSharp.Sql.SqlContext.#ctor(Microsoft.Spark.CSharp.Core.SparkContext)">

--- a/csharp/AdapterTest/AdapterTest.csproj
+++ b/csharp/AdapterTest/AdapterTest.csproj
@@ -25,6 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/csharp/Perf/Microsoft.Spark.CSharp/PerfBenchmark.csproj
+++ b/csharp/Perf/Microsoft.Spark.CSharp/PerfBenchmark.csproj
@@ -23,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -71,8 +72,7 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="CopyCSharpWorker"
-      DependsOnTargets="CoreBuild">
+  <Target Name="CopyCSharpWorker" DependsOnTargets="CoreBuild">
     <Copy SkipUnchangedFiles="true" SourceFiles="$(ProjectDir)..\..\..\csharp\Worker\Microsoft.Spark.CSharp\bin\$(ConfigurationName)\CSharpWorker.*" DestinationFiles="$(TargetDir)" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/csharp/Repl/Repl.csproj
+++ b/csharp/Repl/Repl.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/csharp/ReplTest/ReplTest.csproj
+++ b/csharp/ReplTest/ReplTest.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/csharp/Samples/Microsoft.Spark.CSharp/Samples.csproj
+++ b/csharp/Samples/Microsoft.Spark.CSharp/Samples.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/csharp/Tests.Common/Tests.Common.csproj
+++ b/csharp/Tests.Common/Tests.Common.csproj
@@ -26,6 +26,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/csharp/Utils/Microsoft.Spark.CSharp/Utils.csproj
+++ b/csharp/Utils/Microsoft.Spark.CSharp/Utils.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/csharp/Worker/Microsoft.Spark.CSharp/Worker.csproj
+++ b/csharp/Worker/Microsoft.Spark.CSharp/Worker.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/csharp/WorkerTest/WorkerTest.csproj
+++ b/csharp/WorkerTest/WorkerTest.csproj
@@ -25,6 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/examples/Batch/WordCount/WordCount.csproj
+++ b/examples/Batch/WordCount/WordCount.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/examples/Batch/pi/Pi.csproj
+++ b/examples/Batch/pi/Pi.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/examples/Sql/CassandraDataFrame/CassandraDataFrame.csproj
+++ b/examples/Sql/CassandraDataFrame/CassandraDataFrame.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/examples/Sql/HiveDataFrame/HiveDataFrame.csproj
+++ b/examples/Sql/HiveDataFrame/HiveDataFrame.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/examples/Sql/JdbcDataFrame/JdbcDataFrame.csproj
+++ b/examples/Sql/JdbcDataFrame/JdbcDataFrame.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/examples/Sql/SparkXml/SparkXml.csproj
+++ b/examples/Sql/SparkXml/SparkXml.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/examples/Streaming/EventHub/EventHub.csproj
+++ b/examples/Streaming/EventHub/EventHub.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/examples/Streaming/HdfsWordCount/HdfsWordCount.csproj
+++ b/examples/Streaming/HdfsWordCount/HdfsWordCount.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/examples/Streaming/Kafka/Kafka.csproj
+++ b/examples/Streaming/Kafka/Kafka.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/examples/Streaming/Kafka/MessagePublisher.cs
+++ b/examples/Streaming/Kafka/MessagePublisher.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Spark.CSharp.Examples
             });
             var kafkaProducer = new Producer(kafkaProducerConfig);
 */
-            var topicName = "<kafkaTopicName>";
+            //var topicName = "<kafkaTopicName>";
 
             var now = DateTime.Now.Ticks;
             for (int messageIndex = 1; messageIndex <= 5; messageIndex++)

--- a/examples/fsharp/JsonDataFrame/JsonDataFrame.fsproj
+++ b/examples/fsharp/JsonDataFrame/JsonDataFrame.fsproj
@@ -25,6 +25,8 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DocumentationFile>bin\Debug\JsonDataFrame.XML</DocumentationFile>
     <Prefer32Bit>true</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/examples/fsharp/WordCount/WordCountFSharp.fsproj
+++ b/examples/fsharp/WordCount/WordCountFSharp.fsproj
@@ -25,6 +25,8 @@
     <DocumentationFile>bin\Debug\WordCountFSharp.XML</DocumentationFile>
     <StartArguments>
     </StartArguments>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
This is a code quality improvement. Treating warnings as errors
will stop warnings from getting out of hand, keeping the code base
clean and enforce the use of comments for publicly facing interfaces.