### PR TITLE
Fixed integer Data type issue for UDF

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Sql/Functions.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Sql/Functions.cs
@@ -919,7 +919,7 @@ namespace Microsoft.Spark.CSharp.Sql
             {typeof(double), "double"},
             {typeof(float), "float"},
             {typeof(byte), "tinyint"},
-            {typeof(int), "int"},
+            {typeof(int), "integer"},
             {typeof(long), "bigint"},
             {typeof(short), "smallint"}
         };


### PR DESCRIPTION
int is not valid type in spark, so fixed it to integer