### PR TITLE
README: Twitter badge fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Mobius is licensed under the MIT license. See [LICENSE](LICENSE) file for full l
 [![Issue Stats](http://issuestats.com/github/Microsoft/Mobius/badge/pr)](http://issuestats.com/github/Microsoft/Mobius)
 [![Issue Stats](http://issuestats.com/github/Microsoft/Mobius/badge/issue)](http://issuestats.com/github/Microsoft/Mobius)
 [![Join the chat at https://gitter.im/Microsoft/Mobius](https://badges.gitter.im/Microsoft/Mobius.svg)](https://gitter.im/Microsoft/Mobius?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Twitter](https://img.shields.io/twitter/url/http/twitter.com/MobiusForSpark.svg?style=social)](https://twitter.com/intent/tweet?text=@MobiusForSpark [your tweet] via @GitHub)
+[![Twitter](https://img.shields.io/twitter/url/http/twitter.com/MobiusForSpark.svg?style=social)](https://twitter.com/intent/tweet?text=%40MobiusForSpark%20%5Byour%20tweet%5D%20via%20%40GitHub)
 
 * Mobius project welcomes contributions. To contribute, follow the instructions in [CONTRIBUTING.md](./notes/CONTRIBUTING.md)
 


### PR DESCRIPTION
This change urlencodes the ?text= parameter so that the button can be used as intended.

I've also noticed that the issue stats buttons for pull request / issues are broken. 

I've left this untouched, so that other Hacktoberfest participants may PR against it, if permissible (for removal/replacement/triage).