### PR TITLE
Adding deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mobius development is deprecated and has been superseded by a more recent version '.NET for Apache Spark' from Microsoft ([Website](https://dot.net/spark) | [GitHub](https://github.com/dotnet/spark)) that runs on Azure HDInsight Spark, Azure & AWS Databricks.
+# Mobius development is deprecated and has been superseded by a more recent version '.NET for Apache Spark' from Microsoft ([Website](https://dot.net/spark) | [GitHub](https://github.com/dotnet/spark)) that runs on Azure HDInsight Spark, Amazon EMR Spark, Azure & AWS Databricks.
 
 <img src='logo/mobius-star-200.png' width='125px' alt='Mobius logo' />
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Mobius development is deprecated and has been superseded by a more recent version '.NET for Apache Spark' from Microsoft ([Website](https://dot.net/spark) | [GitHub](https://github.com/dotnet/spark)) that runs on Azure HDInsight Spark, Azure & AWS Databricks.
+
 <img src='logo/mobius-star-200.png' width='125px' alt='Mobius logo' />
 
 # Mobius: C# API for Spark


### PR DESCRIPTION
There is a new project we are open sourcing at this year's Spark+AI Summit 2019: [.NET for Apache Spark](https://databricks.com/sparkaisummit/north-america/sessions-single-2019?id=127). I am opening this PR to reflect a deprecation notice at the top of the README so we can direct new and existing users appropriately to the new project that is actively being developed.

Thank you!